### PR TITLE
Implement negative a support for constants of motion and frequencies.

### DIFF
--- a/Kernel/ConstantsOfMotion.m
+++ b/Kernel/ConstantsOfMotion.m
@@ -62,7 +62,15 @@ KerrGeoConstantsOfMotion[0,p_,e_,x_]:=
 (*Kerr*)
 
 
-(* ::Subsection::Closed:: *)
+(* ::Subsection:: *)
+(*Negative a*)
+
+
+KerrGeoEnergy[a_?Negative,p_,e_,x_]:=KerrGeoEnergy[-a,p,e,-x]
+KerrGeoAngularMomentum[a_?Negative,p_,e_,x_]:=-KerrGeoAngularMomentum[-a,p,e,-x]
+
+
+(* ::Subsection:: *)
 (*Equatorial orbits (x^2 = 1)*)
 
 
@@ -80,7 +88,7 @@ KerrGeoCarterConstant[a_,p_,e_,x_/;x^2==1]:=0
 KerrGeoEnergy[a_,p_,0,x_/;x^2==1]:=((-2+p) Sqrt[p]+a/x)/Sqrt[2 a/x p^(3/2)+(-3+p) p^2]
 
 
-KerrGeoAngularMomentum[a_,p_,0,x_/;x^2==1]:=(a^2-2 a/x Sqrt[p]+p^2)/(Sqrt[2 a/x+(-3+p) Sqrt[p]] p^(3/4))
+KerrGeoAngularMomentum[a_,p_,0,x_/;x^2==1]:=((a^2+p^2)x-2 a Sqrt[p]) /(p^(3/4) Sqrt[x^2 (-3+p) Sqrt[p]+2 a x])
 
 
 (* ::Subsubsection:: *)
@@ -107,7 +115,7 @@ KerrGeoConstantsOfMotion[a_,p_,e_,x:(1|-1)]:=
    "\[ScriptCapitalQ]" -> KerrGeoCarterConstant[a,p,e,x] |>
 
 
-(* ::Subsection::Closed:: *)
+(* ::Subsection:: *)
 (*Polar orbits (x=0)*)
 
 
@@ -118,7 +126,7 @@ KerrGeoConstantsOfMotion[a_,p_,e_,x:(1|-1)]:=
 KerrGeoAngularMomentum[a_,p_,e_,(0|0.)]:=0
 
 
-(* ::Subsubsection::Closed:: *)
+(* ::Subsubsection:: *)
 (*Spherical (e=0)*)
 
 
@@ -132,7 +140,7 @@ KerrGeoEnergy[a_,p_,(0|0.),(0|0.)]:=Sqrt[(p (a^2-2 p+p^2)^2)/((a^2+p^2) (a^2+a^2
 KerrGeoCarterConstant[a_,p_,(0|0.),(0|0.)]:=(p^2 (a^4+2 a^2 (-2+p) p+p^4))/((a^2+p^2) ((-3+p) p^2+a^2 (1+p)))
 
 
-(* ::Subsubsection::Closed:: *)
+(* ::Subsubsection:: *)
 (*Eccentric*)
 
 
@@ -187,11 +195,10 @@ f=p^4+a^2 (p (2+p)-(a^2+(-2+p) p) (-1+x^2));
 KerrGeoEnergy[a_,p_,e_/;e==1,x_]:=1
 
 
-KerrGeoAngularMomentum[a_,p_,e_/;e==1,x_,En1_:Null]:= Module[{En=En1,\[Rho]2,zm},
+KerrGeoAngularMomentum[a_,p_,e_/;e==1,x_,En1_:Null]:= Module[{En=En1,\[Rho]2},
 	If[En==Null,En=KerrGeoEnergy[a,p,e,x]];
 	\[Rho]2=p/(1+e);
-	zm = Sqrt[1-x^2];
-	((1-zm^2) (-2 a \[Rho]2+Sqrt[2] Sqrt[-((\[Rho]2 (a^2+(-2+\[Rho]2) \[Rho]2) (a^2 zm^2+\[Rho]2^2))/(-1+zm^2))]))/(a^2 zm^2+(-2+\[Rho]2) \[Rho]2)
+	((x^2) (-2 a \[Rho]2+Sqrt[2] /x Sqrt[\[Rho]2 (a^2+(-2+\[Rho]2) \[Rho]2) (a^2 (1-x^2)+\[Rho]2^2)]) )/(a^2 (1-x^2)+(-2+\[Rho]2) \[Rho]2)
 ]
 
 

--- a/Kernel/ConstantsOfMotion.m
+++ b/Kernel/ConstantsOfMotion.m
@@ -96,7 +96,7 @@ KerrGeoConstantsOfMotion[0,p_,e_/;e>=1,x_]:=
 (*Kerr*)
 
 
-(* ::Subsection:: *)
+(* ::Subsection::Closed:: *)
 (*Negative a*)
 
 
@@ -104,7 +104,7 @@ KerrGeoEnergy[a_?Negative,p_,e_,x_]:=KerrGeoEnergy[-a,p,e,-x]
 KerrGeoAngularMomentum[a_?Negative,p_,e_,x_]:=-KerrGeoAngularMomentum[-a,p,e,-x]
 
 
-(* ::Subsection:: *)
+(* ::Subsection::Closed:: *)
 (*Equatorial orbits (x^2 = 1)*)
 
 
@@ -149,7 +149,7 @@ KerrGeoConstantsOfMotion[a_,p_,e_,x:(1|-1)]:=
    "\[ScriptCapitalQ]" -> KerrGeoCarterConstant[a,p,e,x] |>
 
 
-(* ::Subsection:: *)
+(* ::Subsection::Closed:: *)
 (*Polar orbits (x=0)*)
 
 
@@ -160,7 +160,7 @@ KerrGeoConstantsOfMotion[a_,p_,e_,x:(1|-1)]:=
 KerrGeoAngularMomentum[a_,p_,e_,(0|0.)]:=0
 
 
-(* ::Subsubsection:: *)
+(* ::Subsubsection::Closed:: *)
 (*Spherical (e=0)*)
 
 
@@ -174,7 +174,7 @@ KerrGeoEnergy[a_,p_,(0|0.),(0|0.)]:=Sqrt[(p (a^2-2 p+p^2)^2)/((a^2+p^2) (a^2+a^2
 KerrGeoCarterConstant[a_,p_,(0|0.),(0|0.)]:=(p^2 (a^4+2 a^2 (-2+p) p+p^4))/((a^2+p^2) ((-3+p) p^2+a^2 (1+p)))
 
 
-(* ::Subsubsection:: *)
+(* ::Subsubsection::Closed:: *)
 (*Eccentric*)
 
 
@@ -222,7 +222,7 @@ f=p^4+a^2 (p (2+p)-(a^2+(-2+p) p) (-1+x^2));
 (*CarterConstant and ConstantsOfMotion calculations are covered by the generic case*)
 
 
-(* ::Subsection:: *)
+(* ::Subsection::Closed:: *)
 (*Marginally bound orbits (e = 1)*)
 
 
@@ -298,21 +298,6 @@ KerrGeoConstantsOfMotion[a_,p_,e_,x_] :=Module[{En,L},
 
  <|"\[ScriptCapitalE]" -> En, "\[ScriptCapitalL]" -> L, "\[ScriptCapitalQ]" -> KerrGeoCarterConstant[a,p,e,x,En,L] |>
  ]
-
-
-(* ::Subsection::Closed:: *)
-(*Generic scattered (e >= 1)*)
-
-
-KerrGeoEnergy[a_,p_,e_/;e==1,x_]:=1
-
-
-KerrGeoAngularMomentum[a_,p_,e_/;e==1,x_,En1_:Null]:= Module[{En=En1,\[Rho]2,zm},
-	If[En==Null,En=KerrGeoEnergy[a,p,e,x]];
-	\[Rho]2=p/(1+e);
-	zm = Sqrt[1-x^2];
-	((1-zm^2) (-2 a \[Rho]2+Sqrt[2] Sqrt[-((\[Rho]2 (a^2+(-2+\[Rho]2) \[Rho]2) (a^2 zm^2+\[Rho]2^2))/(-1+zm^2))]))/(a^2 zm^2+(-2+\[Rho]2) \[Rho]2)
-]
 
 
 (* ::Section::Closed:: *)

--- a/Kernel/FourVelocity.m
+++ b/Kernel/FourVelocity.m
@@ -16,7 +16,14 @@ KerrGeoFourVelocity::usage = "KerrGeoVelocity[a,p,e,x] returns the four-velocity
 Begin["`Private`"];
 
 
-(* ::Section:: *)
+(* ::Subsection::Closed:: *)
+(*Error messages*)
+
+
+KerrGeoFourVelocity::parametrization = "Parameterization error: `1`"
+
+
+(* ::Section::Closed:: *)
 (*Kerr*)
 
 
@@ -178,7 +185,7 @@ u\[Phi] = Function[{Global`\[Chi]}, Evaluate[MinoVelocities [u\[Phi]1][\[Lambda]
 ]
 
 
-(* ::Section:: *)
+(* ::Section::Closed:: *)
 (*KerrGeoFourVelocity Wrapper*)
 
 
@@ -195,19 +202,19 @@ If[OptionValue["Covariant"], index = "Covariant" , index="Contravariant", Messag
 	If[param == "Darwin",
 
 	If[ Abs[x]!=1, 
-		Print["Darwin parameterization only valid for equatorial motion"];
+		Message[KerrGeoFourVelocity::parametrization, "Darwin parameterization only valid for equatorial motion"];
 		Return[];,
 		 Return[KerrGeoVelocityDarwin[a,p,e,x,initPhases, index]]]];
 
 
 	If[param == "Mino", Return[KerrGeoVelocityMino[a,p,e,x,initPhases, index]]];
 
-	Print["Unrecognized Paramaterization: " <>param];
+	Message[KerrGeoFourVelocity::parametrization, "Unrecognized Paramaterization: " <> param];
 
 ]
 
 
-(* ::Section:: *)
+(* ::Section::Closed:: *)
 (*Close the package*)
 
 

--- a/Kernel/KerrGeoOrbit.m
+++ b/Kernel/KerrGeoOrbit.m
@@ -19,6 +19,16 @@ KerrGeoOrbitFunction::usage = "KerrGeoOrbitFunction[a,p,e,x,assoc] an object for
 Begin["`Private`"];
 
 
+(* ::Subsection::Closed:: *)
+(*Error messages*)
+
+
+KerrGeoOrbit::general = "`1`"
+
+
+KerrGeoOrbit::parametrization = "Parametrization error: `1`"
+
+
 (* ::Section::Closed:: *)
 (*Schwarzschild*)
 
@@ -934,7 +944,7 @@ Module[{sampledF,fn,fList,f,sampleN,\[Lambda],integratedF,phaseList,pg,nn,sample
 ];
 
 
-(* ::Subsubsection:: *)
+(* ::Subsubsection::Closed:: *)
 (*Main file that calculates geodesics using spectral integration*)
 
 
@@ -961,8 +971,8 @@ Module[{M=1,consts,En,L,Q,\[CapitalUpsilon]r,\[CapitalUpsilon]\[Theta],\[Capital
 	are given as imaginary for restricted orbits. 
 	Maybe something to fix with KerrGeoMinoFrequencies*)
 	{\[CapitalUpsilon]r,\[CapitalUpsilon]\[Theta],\[CapitalUpsilon]\[Phi],\[CapitalUpsilon]t} = Values[KerrGeodesics`OrbitalFrequencies`Private`KerrGeoMinoFrequencies[a,p,e,x]];
-	If[e>0&&(Im[\[CapitalUpsilon]r]!=0||Re[\[CapitalUpsilon]r]==0),Print["Unstable orbit. Aborting."]; Abort[]];
-	If[r2<1+Sqrt[1-a^2],Print["Unstable orbit. Aborting."]; Abort[]];
+	If[e>0&&(Im[\[CapitalUpsilon]r]!=0||Re[\[CapitalUpsilon]r]==0),Message[KerrGeoOrbit::parametrization, "Unstable orbit. Aborting."]; Abort[]];
+	If[r2<1+Sqrt[1-a^2], Message[KerrGeoOrbit::parametrization, "Unstable orbit. Aborting."]; Abort[]];
 	{\[CapitalUpsilon]r,\[CapitalUpsilon]\[Theta],\[CapitalUpsilon]\[Phi],\[CapitalUpsilon]t} = Re[{\[CapitalUpsilon]r,\[CapitalUpsilon]\[Theta],\[CapitalUpsilon]\[Phi],\[CapitalUpsilon]t}];
 	
 	(*Parameterize r and \[Theta] in terms of Darwin-like parameters \[Psi] and \[Chi]*)
@@ -1027,7 +1037,7 @@ Module[{M=1,consts,En,L,Q,\[CapitalUpsilon]r,\[CapitalUpsilon]\[Theta],\[Capital
 			qr0=\[CapitalUpsilon]r*\[Lambda]r[\[Psi]0]+\[Psi]0;
 			q\[Theta]0=\[CapitalUpsilon]\[Theta]*\[Lambda]\[Theta][\[Chi]0]+\[Chi]0;
 			q\[Phi]0=\[Phi]Init,
-			Print["{t,r,\[Theta],\[Phi]} = "<>ToString[{tInit,rInit,\[Theta]Init,\[Phi]Init}]<>" is not a valid set of initial coordinates"]
+			Message[KerrGeoOrbit::parametrization, "{t,r,\[Theta],\[Phi]} = "<>ToString[{tInit,rInit,\[Theta]Init,\[Phi]Init}]<>" is not a valid set of initial coordinates"]
 		]
 	];
 	If[\[CapitalUpsilon]r==0,\[Lambda]r0=0,\[Lambda]r0=qr0/\[CapitalUpsilon]r];
@@ -1084,7 +1094,7 @@ KerrGeoOrbit[a_,p_,e_,x_, initPhases:{_,_,_,_}:{0,0,0,0},OptionsPattern[]]:=Modu
 method = OptionValue["Method"];
 param = OptionValue["Parametrization"];
 
-If[param == "Darwin" && Abs[x]!=1, Print["Darwin parameterization only valid for equatorial motion"];Return[];];
+If[param == "Darwin" && Abs[x]!=1, Message[KerrGeoOrbit::parametrization, "Darwin parameterization only valid for equatorial motion"]; Return[];];
 
 If[Precision[{a,p,e,x}] > 30, method = "Analytic"];
 
@@ -1105,11 +1115,11 @@ If[method == "Analytic",
 	If[param == "Darwin", 
 		If[PossibleZeroQ[a], Return[KerrGeoOrbitSchwarzDarwin[p, e]], Return[KerrGeoOrbitEquatorialDarwin[a,p,e,x,initPhases]]]
 	];
-	Print["Unrecognized parametrization: " <> OptionValue["Parametrization"]];
+	Message[KerrGeoOrbit::parametrization, "Unrecognized parametrization: " <> OptionValue["Parametrization"]];
 
 ];
 
-Print["Unrecognized method: " <> method];
+Message[KerrGeoOrbit::general, "Method " <> method <> " is not one of {FastSpec, Analytic}"];
 
 ]
 

--- a/Kernel/KerrGeoOrbit.m
+++ b/Kernel/KerrGeoOrbit.m
@@ -1104,7 +1104,7 @@ If[method == "FastSpec",
 	If[param == "Darwin", 
 		If[PossibleZeroQ[a], Return[KerrGeoOrbitSchwarzDarwin[p, e]], Return[KerrGeoOrbitFastSpecDarwin[a,p,e,x,initPhases]]]
 	];
-	Print["Unrecognized parametrization: " <> OptionValue["Parametrization"]];
+	Message[KerrGeoOrbit::parametrization, "Unrecognized parametrization: " <> OptionValue["Parametrization"]];
 	
 ];
 

--- a/Kernel/OrbitalFrequencies.m
+++ b/Kernel/OrbitalFrequencies.m
@@ -62,6 +62,14 @@ KerrGeoPolarRoots[a_, p_, e_, x_] := Module[{En,L,Q,zm,zp},
 ]
 
 
+KerrGeoPolarRoots[a_, p_, e_, x_?PossibleZeroQ] := Module[{En,L,Q,zm,zp},
+  {En,L,Q} = Values[KerrGeoConstantsOfMotion[a, p, e, x]];
+  zm = Sqrt[1-x^2];
+  zp = (Q)^(1/2);
+  {zp,zm}
+]
+
+
 (* ::Section:: *)
 (*Orbital Frequencies*)
 
@@ -74,31 +82,34 @@ KerrGeoPolarRoots[a_, p_, e_, x_] := Module[{En,L,Q,zm,zp},
 (*Schwarzschild*)
 
 
+sgn[x_]=Piecewise[{{-1,Negative[x]}},1]
+
+
 KerrGeoMinoFrequencies[a_?PossibleZeroQ, p_, e_?PossibleZeroQ,x_] :=
  <| "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(r\)]\)" -> Sqrt[((-6+p) p)/(-3+p)],
-    "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Theta]\)]\)" -> p Sqrt[1/((-3+p) x^2)] x,
-    "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Phi]\)]\)" -> (p x)/Sqrt[(-3+p) x^2],
+    "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Theta]\)]\)" -> p Sqrt[1/((-3+p))] ,
+    "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Phi]\)]\)" -> (p sgn[x])/Sqrt[(-3+p)],
     "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(t\)]\)"  -> Sqrt[p^5/(-3+p)] |>;
 
 
 KerrGeoMinoFrequencies[a_?PossibleZeroQ, p_,e_,x_] :=
  <| "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(r\)]\)" -> (Sqrt[-((p (-6+2 e+p))/(3+e^2-p))] \[Pi])/(2 EllipticK[(4 e)/(-6+2 e+p)]),
     "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Theta]\)]\)" -> p/Sqrt[-3-e^2+p],
-    "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Phi]\)]\)" -> (p x)/(Sqrt[-3-e^2+p] Abs[x]),
+    "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Phi]\)]\)" -> (p sgn[x])/(Sqrt[-3-e^2+p]),
     "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(t\)]\)" -> 1/2 Sqrt[(-4 e^2+(-2+p)^2)/(p (-3-e^2+p))] (8+1/((-4+p)^2 EllipticK[(4 e)/(-6+2 e+p)]) (-(((-4+p) p^2 (-6+2 e+p) EllipticE[(4 e)/(-6+2 e+p)])/(-1+e^2))+(p^2 (28+4 e^2-12 p+p^2) EllipticK[(4 e)/(-6+2 e+p)])/(-1+e^2)-(2 (6+2 e-p) (3+e^2-p) p^2 EllipticPi[(2 e (-4+p))/((1+e) (-6+2 e+p)),(4 e)/(-6+2 e+p)])/((-1+e) (1+e)^2)+(4 (-4+p) p (2 (1+e) EllipticK[(4 e)/(-6+2 e+p)]+(-6-2 e+p) EllipticPi[(2 e (-4+p))/((1+e) (-6+2 e+p)),(4 e)/(-6+2 e+p)]))/(1+e)+2 (-4+p)^2 ((-4+p) EllipticK[(4 e)/(-6+2 e+p)]-((6+2 e-p) p EllipticPi[(16 e)/(12+8 e-4 e^2-8 p+p^2),(4 e)/(-6+2 e+p)])/(2+2 e-p)))) |>;
 
 
 KerrGeoMinoFrequencies[a_?PossibleZeroQ, p_,e_/;e==1,x_] :=
  <| "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(r\)]\)" -> (Sqrt[-((p (-6+2 e+p))/(3+e^2-p))] \[Pi])/(2 EllipticK[(4 e)/(-6+2 e+p)]),
     "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Theta]\)]\)" -> p/Sqrt[-3-e^2+p],
-    "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Phi]\)]\)" -> (p x)/(Sqrt[-3-e^2+p] Abs[x]),
+    "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Phi]\)]\)" -> (p sgn[x])/(Sqrt[-3-e^2+p]),
     "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(t\)]\)"  -> \[Infinity] |>;
 
 
 KerrGeoBoyerLindquistFrequencies[a_?PossibleZeroQ, p_, e_?PossibleZeroQ,x_] :=
  <| "\!\(\*SubscriptBox[\(\[CapitalOmega]\), \(r\)]\)" -> Sqrt[-6+p]/p^2,
-    "\!\(\*SubscriptBox[\(\[CapitalOmega]\), \(\[Theta]\)]\)" -> (Sqrt[1/x^2] x)/p^(3/2),
-    "\!\(\*SubscriptBox[\(\[CapitalOmega]\), \(\[Phi]\)]\)" -> (p x)/Sqrt[p^5 x^2] |>;
+    "\!\(\*SubscriptBox[\(\[CapitalOmega]\), \(\[Theta]\)]\)" -> (1)/p^(3/2),
+    "\!\(\*SubscriptBox[\(\[CapitalOmega]\), \(\[Phi]\)]\)" -> (p Sign[x])/Sqrt[p^5] |>;
 
 
 KerrGeoProperFrequencyFactor[_,p_,e_/;e==1,x_]:=\[Infinity]
@@ -112,6 +123,146 @@ KerrGeoProperFrequencyFactor[a_?PossibleZeroQ ,p_,e_,x_]:=(p^2 ((1+e) (28+4 e^2+
 
 (* ::Subsection:: *)
 (*Kerr*)
+
+
+(* ::Subsubsection:: *)
+(*KerrGeoMinoFrequencyr*)
+
+
+KerrGeoMinoFrequencyr[a_,p_,e_,x_,{En_,L_,Q_},{\[Rho]1_,\[Rho]2_,\[Rho]3_,\[Rho]4_}]:=Module[{kr},
+	kr= (\[Rho]1-\[Rho]2)/(\[Rho]1-\[Rho]3) (\[Rho]3-\[Rho]4)/(\[Rho]2-\[Rho]4);
+	(\[Pi] Sqrt[(1-En^2)(\[Rho]1-\[Rho]3)(\[Rho]2-\[Rho]4)])/(2 EllipticK[kr])
+]
+
+
+KerrGeoMinoFrequencyr[a_,p_,e_/;e==1,x_,{En_,L_,Q_},{\[Rho]1_,\[Rho]2_,\[Rho]3_,\[Rho]4_}]:=Module[{kr},
+	kr=(\[Rho]3-\[Rho]4)/(\[Rho]2-\[Rho]4);
+	(\[Pi] Sqrt[2(\[Rho]2-\[Rho]4)])/(2 EllipticK[kr])
+]
+
+
+KerrGeoMinoFrequencyr[a_?PossibleZeroQ,p_,e_?PossibleZeroQ,x_,{En_,L_,Q_},{\[Rho]1_,\[Rho]2_,\[Rho]3_,\[Rho]4_}]:=Module[{},
+	Sqrt[((-6+p) p)/(-3+p)]
+]
+
+
+(* ::Subsubsection:: *)
+(*KerrGeoMinoFrequency\[Theta]*)
+
+
+KerrGeoMinoFrequency\[Theta][a_,p_,e_,x_,{En_,L_,Q_},{zp_,zm_}]:=Module[{},
+   (\[Pi]  zp)/(2EllipticK[a^2 (1-En^2)(zm/zp)^2])
+]
+
+
+KerrGeoMinoFrequency\[Theta][a_,p_,e_/;e==1,x_,{En_,L_,Q_},{zp_,zm_}]:=Module[{},
+  zp
+]
+
+
+(* ::Subsubsection:: *)
+(*KerrGeoMinoFrequency\[Phi]*)
+
+
+KerrGeoMinoFrequency\[Phi][a_,p_,e_,x_,{En_,L_,Q_},{\[Rho]1_,\[Rho]2_,\[Rho]3_,\[Rho]4_},{zp_,zm_}]:=KerrGeoMinoFrequency\[Phi]r[a,p,e,x,{En,L,Q},{\[Rho]1,\[Rho]2,\[Rho]3,\[Rho]4}]+KerrGeoMinoFrequency\[Phi]\[Theta][a,p,e,x,{En,L,Q},{zp,zm}]
+
+
+KerrGeoMinoFrequency\[Phi]r[a_,p_,e_,x_,{En_,L_,Q_},{\[Rho]1_,\[Rho]2_,\[Rho]3_,\[Rho]4_}]:=Module[{\[Rho]in,\[Rho]out,kr,hin,hout},
+	\[Rho]in= 1-Sqrt[1-a^2];\[Rho]out= 1+Sqrt[1-a^2];
+	kr= (\[Rho]1-\[Rho]2)/(\[Rho]1-\[Rho]3) (\[Rho]3-\[Rho]4)/(\[Rho]2-\[Rho]4);
+	hout= (\[Rho]1-\[Rho]2)/(\[Rho]1-\[Rho]3) (\[Rho]3-\[Rho]out)/(\[Rho]2-\[Rho]out);
+	hin= (\[Rho]1-\[Rho]2)/(\[Rho]1-\[Rho]3) (\[Rho]3-\[Rho]in)/(\[Rho]2-\[Rho]in);
+	 a/(2Sqrt[1-a^2]) ((2 En \[Rho]out-a L)/(\[Rho]3-\[Rho]out) (1-(\[Rho]2-\[Rho]3)/(\[Rho]2-\[Rho]out) EllipticPi[hout,kr]/EllipticK[kr])-(2 En \[Rho]in-a L)/(\[Rho]3-\[Rho]in) (1-(\[Rho]2-\[Rho]3)/(\[Rho]2-\[Rho]in) EllipticPi[hin,kr]/EllipticK[kr]))
+]
+
+
+KerrGeoMinoFrequency\[Phi]r[a_/;a^2==1,p_,e_,x_,{En_,L_,Q_},{\[Rho]1_,\[Rho]2_,\[Rho]3_,\[Rho]4_}]:=Module[{\[Rho]in,\[Rho]out,kr,hM},
+	\[Rho]in= 1-Sqrt[1-a^2];\[Rho]out= 1+Sqrt[1-a^2];
+	kr= (\[Rho]1-\[Rho]2)/(\[Rho]1-\[Rho]3) (\[Rho]3-\[Rho]4)/(\[Rho]2-\[Rho]4);
+	hM= (\[Rho]1-\[Rho]2)/(\[Rho]1-\[Rho]3) (\[Rho]3-1)/(\[Rho]2-1);
+	a En(2/(\[Rho]3-1) (1-(\[Rho]2-\[Rho]3)/(\[Rho]2-1) EllipticPi[hM,kr]/EllipticK[kr])+(2-a L/En)/(2(\[Rho]3-1)^2) ((2-((\[Rho]1-\[Rho]3)(\[Rho]2-\[Rho]3))/((\[Rho]1-1)(\[Rho]2-1)))+((\[Rho]1-\[Rho]3)(\[Rho]2-\[Rho]4)(\[Rho]3-1))/((\[Rho]1-1)(\[Rho]2-1)(\[Rho]4-1)) EllipticE[kr]/EllipticK[kr]+(\[Rho]2-\[Rho]3)/(\[Rho]2-1) ((\[Rho]1-\[Rho]3)/(\[Rho]1-1)+(\[Rho]2-\[Rho]3)/(\[Rho]2-1)+(\[Rho]4-\[Rho]3)/(\[Rho]4-1)-4) EllipticPi[hM,kr]/EllipticK[kr]))
+]
+
+
+KerrGeoMinoFrequency\[Phi]r[a_,p_,e_/;e==1,x_,{En_,L_,Q_},{\[Rho]1_,\[Rho]2_,\[Rho]3_,\[Rho]4_}]:=Module[{\[Rho]in,\[Rho]out,kr,hin,hout},
+	\[Rho]in= 1-Sqrt[1-a^2];\[Rho]out= 1+Sqrt[1-a^2];
+	kr= (\[Rho]3-\[Rho]4)/(\[Rho]2-\[Rho]4);
+	hout= (\[Rho]3-\[Rho]out)/(\[Rho]2-\[Rho]out);
+	hin= (\[Rho]3-\[Rho]in)/(\[Rho]2-\[Rho]in);
+	  a/(2Sqrt[1-a^2]) ((2  \[Rho]out-a L)/(\[Rho]3-\[Rho]out) (1-(\[Rho]2-\[Rho]3)/(\[Rho]2-\[Rho]out) EllipticPi[hout,kr]/EllipticK[kr])-(2  \[Rho]in-a L)/(\[Rho]3-\[Rho]in) (1-(\[Rho]2-\[Rho]3)/(\[Rho]2-\[Rho]in) EllipticPi[hin,kr]/EllipticK[kr]))
+]
+
+
+KerrGeoMinoFrequency\[Phi]r[a_/;a^2==1,p_,e_/;e==1,x_,{En_,L_,Q_},{\[Rho]1_,\[Rho]2_,\[Rho]3_,\[Rho]4_}]:=Module[{kr,hM},
+	kr= (\[Rho]3-\[Rho]4)/(\[Rho]2-\[Rho]4);
+	hM= (\[Rho]3-1)/(\[Rho]2-1);
+	  a(2/(\[Rho]3-1) (1-(\[Rho]2-\[Rho]3)/(\[Rho]2-1) EllipticPi[hM,kr]/EllipticK[kr])+(2-a L)/(2(\[Rho]3-1)^2) ((2-(\[Rho]2-\[Rho]3)/(\[Rho]2-1))+((\[Rho]2-\[Rho]4)(\[Rho]3-1))/((\[Rho]2-1)(\[Rho]4-1)) EllipticE[kr]/EllipticK[kr]+(\[Rho]2-\[Rho]3)/(\[Rho]2-1) (1+(\[Rho]2-\[Rho]3)/(\[Rho]2-1)+(\[Rho]4-\[Rho]3)/(\[Rho]4-1)-4) EllipticPi[hM,kr]/EllipticK[kr]))
+]
+
+
+KerrGeoMinoFrequency\[Phi]\[Theta][a_,p_,e_,x_,{En_,L_,Q_},{zp_,zm_}]:=Module[{},
+    ( L EllipticPi[zm^2,a^2 (1-En^2)(zm/zp)^2])/EllipticK[a^2 (1-En^2)(zm/zp)^2]
+]
+
+
+KerrGeoMinoFrequency\[Phi]\[Theta][a_,p_,e_,x_?PossibleZeroQ,{En_,L_,Q_},{zp_,zm_}]:=Module[{\[Rho]1,\[Rho]2,\[Rho]3,\[Rho]4},
+	{\[Rho]1,\[Rho]2,\[Rho]3,\[Rho]4} = KerrGeoRadialRoots[a,p,e,x,En,Q];
+	\[Pi] Sqrt[((\[Rho]1 \[Rho]2 (a^4+\[Rho]1^2 \[Rho]2^2+a^2 ((-2+\[Rho]1) \[Rho]1+(-2+\[Rho]2) \[Rho]2))/2)/(a^4 (2+\[Rho]1+\[Rho]2)+\[Rho]1 \[Rho]2 (\[Rho]1^2 (-2+\[Rho]2)+\[Rho]1 (-2+\[Rho]2) \[Rho]2-2 \[Rho]2^2)+a^2 (\[Rho]1^3+\[Rho]1^2 \[Rho]2+\[Rho]1 (-4+\[Rho]2) \[Rho]2+\[Rho]2^3)))]/EllipticK[(a^2 (a^4+\[Rho]1 (\[Rho]1 (-2+\[Rho]2)-2 \[Rho]2) \[Rho]2+a^2 (\[Rho]1^2+\[Rho]2^2)))/(\[Rho]1 \[Rho]2 (a^4+\[Rho]1^2 \[Rho]2^2+a^2 ((-2+\[Rho]1) \[Rho]1+(-2+\[Rho]2) \[Rho]2)))]
+]
+
+
+KerrGeoMinoFrequency\[Phi]\[Theta][a_,p_,e_/;e==1,x_?PossibleZeroQ,{En_,L_,Q_},{zp_,zm_}]:=Module[{\[Rho]1,\[Rho]2,\[Rho]3,\[Rho]4},
+	{\[Rho]1,\[Rho]2,\[Rho]3,\[Rho]4} = KerrGeoRadialRoots[a,p,e,x,En,Q];
+    Sqrt[2] Sqrt[(\[Rho]2 (a^2+\[Rho]2^2))/(a^2+(-2+\[Rho]2) \[Rho]2)]
+]
+
+
+(* ::Subsubsection:: *)
+(*KerrGeoMinoFrequencyt*)
+
+
+KerrGeoMinoFrequencyt[a_,p_,e_,x_,{En_,L_,Q_},{\[Rho]1_,\[Rho]2_,\[Rho]3_,\[Rho]4_},{zp_,zm_}]:=KerrGeoMinoFrequencytr[a,p,e,x,{En,L,Q},{\[Rho]1,\[Rho]2,\[Rho]3,\[Rho]4}]+KerrGeoMinoFrequencyt\[Theta][a,p,e,x,{En,L,Q},{zp,zm}]
+
+
+KerrGeoMinoFrequencytr[a_,p_,e_,x_,{En_,L_,Q_},{\[Rho]1_,\[Rho]2_,\[Rho]3_,\[Rho]4_}]:=Module[{\[Rho]in,\[Rho]out,kr,hin,hout,hr},
+	\[Rho]in= 1-Sqrt[1-a^2];\[Rho]out= 1+Sqrt[1-a^2];
+	kr= (\[Rho]1-\[Rho]2)/(\[Rho]1-\[Rho]3) (\[Rho]3-\[Rho]4)/(\[Rho]2-\[Rho]4);
+	hout= (\[Rho]1-\[Rho]2)/(\[Rho]1-\[Rho]3) (\[Rho]3-\[Rho]out)/(\[Rho]2-\[Rho]out);
+	hin= (\[Rho]1-\[Rho]2)/(\[Rho]1-\[Rho]3) (\[Rho]3-\[Rho]in)/(\[Rho]2-\[Rho]in);
+	hr=(\[Rho]1-\[Rho]2)/(\[Rho]1-\[Rho]3);
+	(a^2+4)En+En(1/2 (\[Rho]3(\[Rho]1+\[Rho]2+\[Rho]3)-\[Rho]1 \[Rho]2+(\[Rho]1+\[Rho]2+\[Rho]3+\[Rho]4)(\[Rho]2-\[Rho]3) EllipticPi[hr,kr]/EllipticK[kr]+(\[Rho]1-\[Rho]3)(\[Rho]2-\[Rho]4) EllipticE[kr]/EllipticK[kr])+2(\[Rho]3+(\[Rho]2-\[Rho]3) EllipticPi[hr,kr]/EllipticK[kr])+1/Sqrt[1-a^2] (((4-a L/En)\[Rho]out-2a^2)/(\[Rho]3-\[Rho]out) (1-(\[Rho]2-\[Rho]3)/(\[Rho]2-\[Rho]out) EllipticPi[hout,kr]/EllipticK[kr])-((4-a L/En)\[Rho]in-2a^2)/(\[Rho]3-\[Rho]in) (1-( \[Rho]2-\[Rho]3)/(\[Rho]2-\[Rho]in) EllipticPi[hin,kr]/EllipticK[kr])))
+]
+
+
+KerrGeoMinoFrequencytr[a_,p_,e_/;e==1,x_,{En_,L_,Q_},{\[Rho]1_,\[Rho]2_,\[Rho]3_,\[Rho]4_}]:=\[Infinity]
+
+
+KerrGeoMinoFrequencytr[a_/;a^2==1,p_,e_,x_,{En_,L_,Q_},{\[Rho]1_,\[Rho]2_,\[Rho]3_,\[Rho]4_}]:=Module[{\[Rho]in,\[Rho]out,kr,hM,hr},
+	\[Rho]in= 1-Sqrt[1-a^2];\[Rho]out= 1+Sqrt[1-a^2];
+	kr= (\[Rho]1-\[Rho]2)/(\[Rho]1-\[Rho]3) (\[Rho]3-\[Rho]4)/(\[Rho]2-\[Rho]4);
+	hM= (\[Rho]1-\[Rho]2)/(\[Rho]1-\[Rho]3) (\[Rho]3-1)/(\[Rho]2-1);
+	hr=(\[Rho]1-\[Rho]2)/(\[Rho]1-\[Rho]3);
+	5En+En(1/2 ((\[Rho]3(\[Rho]1+\[Rho]2+\[Rho]3)-\[Rho]1 \[Rho]2)+(\[Rho]1+\[Rho]2+\[Rho]3+\[Rho]4)(\[Rho]2-\[Rho]3) EllipticPi[hr,kr]/EllipticK[kr]+(\[Rho]1-\[Rho]3)(\[Rho]2-\[Rho]4)  EllipticE[kr]/EllipticK[kr])+2(\[Rho]3+(\[Rho]2-\[Rho]3) EllipticPi[hr,kr]/EllipticK[kr])+(2(4-a L/En))/(\[Rho]3-1) (1-(\[Rho]2-\[Rho]3)/(\[Rho]2-1) EllipticPi[hM,kr]/EllipticK[kr])+(2-a L/En)/(\[Rho]3-1)^2 ((2-((\[Rho]1-\[Rho]3)(\[Rho]2-\[Rho]3))/((\[Rho]1-1)(\[Rho]2-1)))+((\[Rho]1-\[Rho]3)(\[Rho]2-\[Rho]4)(\[Rho]3-1))/((\[Rho]1-1)(\[Rho]2-1)(\[Rho]4-1)) EllipticE[kr]/EllipticK[kr]+(\[Rho]2-\[Rho]3)/(\[Rho]2-1) ((\[Rho]1-\[Rho]3)/(\[Rho]1-1)+(\[Rho]2-\[Rho]3)/(\[Rho]2-1)+(\[Rho]4-\[Rho]3)/(\[Rho]4-1)-4) EllipticPi[hM,kr]/EllipticK[kr]))
+]
+
+
+KerrGeoMinoFrequencyt\[Theta][a_,p_,e_,x_,{En_,L_,Q_},{zp_,zm_}]:=Module[{},
+   (En Q)/((1-En^2) zm^2) (1- EllipticE[a^2 (1-En^2)(zm/zp)^2]/EllipticK[(1-En^2)(zm/zp)^2])-a^2 En
+]
+
+
+KerrGeoMinoFrequencyt\[Theta][a_,p_,e_/;e==1,x_,{En_,L_,Q_},{zp_,zm_}]:=Module[{},
+   -a^2+(a^2 Q)/(2 zp^2)
+]
+
+
+KerrGeoMinoFrequencyt\[Theta][a_,p_,e_,x_/;x^2==1,{En_,L_,Q_},{zp_,zm_}]:=Module[{},
+   -a^2En
+]
+
+
+(* ::Subsubsection:: *)
+(*KerrGeoMinoFrequencies*)
 
 
 KerrGeoMinoFrequencies[a_?Negative,p_,e_,x_]:=<|"\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(r\)]\)"->1,"\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Theta]\)]\)"->1,"\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Phi]\)]\)"->-1,"\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(t\)]\)"->1|>KerrGeoMinoFrequencies[-a,p,e,-x]
@@ -132,155 +283,22 @@ KerrGeoMinoFrequencies[a_,p_,e_?PossibleZeroQ, 1] := Module[{\[CapitalUpsilon]r,
 ]
 
 
-KerrGeoMinoFrequencies[a_,p_,e_,x_]:=Module[{M=1,En,L,Q,r1,r2,r3,r4,\[Epsilon]0,zm,a2zp,\[Epsilon]0zp,zmOverZp,kr,k\[Theta],\[CapitalUpsilon]r,\[CapitalUpsilon]\[Theta],rp,rm,hr,hp,hm,\[CapitalUpsilon]\[Phi],\[CapitalGamma]},
+KerrGeoMinoFrequencies[a_,p_,e_,x_]:=Module[{En,L,Q,r1,r2,r3,r4,zm,zp,\[CapitalUpsilon]r,\[CapitalUpsilon]\[Theta],\[CapitalUpsilon]\[Phi],\[CapitalUpsilon]t},
 {En,L,Q} = Values[KerrGeoConstantsOfMotion[a,p,e,x]];
 
 {r1,r2,r3,r4} = KerrGeoRadialRoots[a,p,e,x,En,Q];
-\[Epsilon]0=a^2 (1-En^2)/L^2;
-zm=1-x^2;
-a2zp=(L^2+a^2 (-1+En^2) (-1+zm))/( (-1+En^2) (-1+zm));
+{zp,zm}=KerrGeoPolarRoots[a,p,e,x];
 
-\[Epsilon]0zp=-((L^2+a^2 (-1+En^2) (-1+zm))/(L^2 (-1+zm)));
-
-(*zmOverZp=If[a==0,0,zm/((L^2+a^2 (-1+En^2) (-1+zm))/(a^2 (-1+En^2) (-1+zm)))];*)
-zmOverZp=zm/((L^2+a^2 (-1+En^2) (-1+zm))/(a^2 (-1+En^2) (-1+zm)));
-
-
-kr=Sqrt[(r1-r2)/(r1-r3) (r3-r4)/(r2-r4)];(*Eq.(13)*)
-k\[Theta]=Sqrt[zmOverZp];(*Eq.(13)*)
-\[CapitalUpsilon]r=(Pi Sqrt[(1-En^2)(r1-r3)(r2-r4)])/(2EllipticK[kr^2]);(*Eq.(15)*)
-\[CapitalUpsilon]\[Theta]=(Pi L Sqrt[\[Epsilon]0zp])/(2EllipticK[k\[Theta]^2]);(*Eq.(15)*)
-
-rp=M+Sqrt[M^2-a^2];
-rm=M-Sqrt[M^2-a^2];
-hr=(r1-r2)/(r1-r3);
-hp=((r1-r2)(r3-rp))/((r1-r3)(r2-rp));
-hm=((r1-r2)(r3-rm))/((r1-r3)(r2-rm));
-
-(*Eq. (21)*)
-\[CapitalUpsilon]\[Phi]=(2\[CapitalUpsilon]\[Theta])/(Pi Sqrt[\[Epsilon]0zp]) EllipticPi[zm,k\[Theta]^2]+(2a \[CapitalUpsilon]r)/(Pi(rp-rm)Sqrt[(1-En^2)(r1-r3)(r2-r4)])((2M En rp - a L)/(r3-rp) (EllipticK[kr^2]-(r2-r3)/(r2-rp) EllipticPi[hp,kr^2])-(2M En rm - a L)/(r3-rm) (EllipticK[kr^2]-(r2-r3)/(r2-rm) EllipticPi[hm,kr^2]));
-
-
-\[CapitalGamma]=4M^2 En + (2a2zp En  \[CapitalUpsilon]\[Theta])/(Pi L Sqrt[\[Epsilon]0zp]) (EllipticK[k\[Theta]^2]- EllipticE[k\[Theta]^2]) + (2\[CapitalUpsilon]r)/(Pi Sqrt[(1-En^2)(r1-r3)(r2-r4)]) (En/2 ((r3(r1+r2+r3)-r1 r2)EllipticK[kr^2]+(r2-r3)(r1+r2+r3+r4)EllipticPi[hr,kr^2]+(r1-r3)(r2-r4)EllipticE[kr^2])+2M En(r3 EllipticK[kr^2]+(r2-r3)EllipticPi[hr,kr^2])+(2M)/(rp-rm) (((4M^2 En-a L)rp-2M a^2 En)/(r3-rp) (EllipticK[kr^2]-(r2-r3)/(r2-rp) EllipticPi[hp,kr^2])-((4M^2 En-a L)rm-2M a^2 En)/(r3-rm) (EllipticK[kr^2]-(r2-r3)/(r2-rm) EllipticPi[hm,kr^2])));
+\[CapitalUpsilon]r= KerrGeoMinoFrequencyr[a,p,e,x,{En,L,Q},{r1,r2,r3,r4}];
+\[CapitalUpsilon]\[Theta]= KerrGeoMinoFrequency\[Theta][a,p,e,x,{En,L,Q},{zp,zm}];
+\[CapitalUpsilon]\[Phi]= KerrGeoMinoFrequency\[Phi][a,p,e,x,{En,L,Q},{r1,r2,r3,r4},{zp,zm}];
+\[CapitalUpsilon]t= KerrGeoMinoFrequencyt[a,p,e,x,{En,L,Q},{r1,r2,r3,r4},{zp,zm}];
 
  <| "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(r\)]\)" -> \[CapitalUpsilon]r,
     "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Theta]\)]\)" -> Abs[\[CapitalUpsilon]\[Theta]],
     "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Phi]\)]\)" -> \[CapitalUpsilon]\[Phi],
-    "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(t\)]\)" -> \[CapitalGamma] |>
+    "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(t\)]\)" -> \[CapitalUpsilon]t |>
 
-]
-
-
-KerrGeoMinoFrequencies[a_,p_,e_/;e==1,x_]:=Module[{M=1,En,L,Q,r1,r2,r3,r4,\[Epsilon]0,zm,a2zp,\[Epsilon]0zp,zmOverZp,kr,k\[Theta],\[CapitalUpsilon]r,\[CapitalUpsilon]\[Theta],rp,rm,hr,hp,hm,\[CapitalUpsilon]\[Phi],\[CapitalGamma]},
-{En,L,Q} = Values[KerrGeoConstantsOfMotion[a,p,e,x]];
-
-{r1,r2,r3,r4} = KerrGeoRadialRoots[a,p,e,x,En,Q];
-\[Epsilon]0=a^2 (1-En^2)/L^2;
-zm=1-x^2;
-(*a2zp=(L^2+a^2 (-1+En^2) (-1+zm))/( (-1+En^2) (-1+zm));*)
-
-\[Epsilon]0zp=-(1/((-1+zm)));
-
-(*zmOverZp=If[a==0,0,zm/((L^2+a^2 (-1+En^2) (-1+zm))/(a^2 (-1+En^2) (-1+zm)))];*)
-(*zmOverZp=(-1+En^2)zm/((L^2+a^2 (-1+En^2) (-1+zm))/(a^2  (-1+zm)));*)
-
-
-kr=Sqrt[(r3-r4)/(r2-r4)];
-k\[Theta]=0;(*Eq.(13)*)
-\[CapitalUpsilon]r=(Pi Sqrt[2(r2-r4)])/(2EllipticK[kr^2]);
-\[CapitalUpsilon]\[Theta]=( L Sqrt[\[Epsilon]0zp]);
-
-rp=M+Sqrt[M^2-a^2];
-rm=M-Sqrt[M^2-a^2];
-hr=1;
-hp=((r3-rp))/((r2-rp));
-hm=((r3-rm))/((r2-rm));
-
-(*Eq. (21)*)
-\[CapitalUpsilon]\[Phi]=  (2\[CapitalUpsilon]\[Theta])/(Pi Sqrt[\[Epsilon]0zp]) EllipticPi[zm,k\[Theta]^2]+a/(2Sqrt[1-a^2]) ((2  rp-a L)/(r3-rp) (1-(r2-r3)/(r2-rp) EllipticPi[hp,kr^2]/EllipticK[kr^2])-(2  rm-a L)/(r3-rm) (1-(r2-r3)/(r2-rm) EllipticPi[hm,kr^2]/EllipticK[kr^2]));
-
-\[CapitalGamma] = \[Infinity];
-
-
- <| "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(r\)]\)" -> \[CapitalUpsilon]r,
-    "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Theta]\)]\)" -> Abs[\[CapitalUpsilon]\[Theta]],
-    "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Phi]\)]\)" -> \[CapitalUpsilon]\[Phi],
-    "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(t\)]\)" -> \[CapitalGamma] |>
-
-]
-
-
-KerrGeoMinoFrequencies[(1|1.),p_,e_/;e==1,x_]:=Module[{M=1,a=1,En,L,Q,r1,r2,r3,r4,\[Epsilon]0,zm,a2zp,\[Epsilon]0zp,zmOverZp,kr,k\[Theta],\[CapitalUpsilon]r,\[CapitalUpsilon]\[Theta],rp,rm,hr,hM,\[CapitalUpsilon]\[Phi],\[CapitalGamma]},
-
-{En,L,Q} = Values[KerrGeoConstantsOfMotion[a,p,e,x]];
-
-{r1,r2,r3,r4} = KerrGeoRadialRoots[a,p,e,x,En,Q];
-\[Epsilon]0=a^2 (1-En^2)/L^2;
-zm=1-x^2;
-(*a2zp=(L^2+a^2 (-1+En^2) (-1+zm))/( (-1+En^2) (-1+zm));*)
-
-\[Epsilon]0zp=-(1/((-1+zm)));
-
-(*zmOverZp=If[a==0,0,zm/((L^2+a^2 (-1+En^2) (-1+zm))/(a^2 (-1+En^2) (-1+zm)))];*)
-(*zmOverZp=(-1+En^2)zm/((L^2+a^2 (-1+En^2) (-1+zm))/(a^2  (-1+zm)));
-*)
-
-kr=Sqrt[(r3-r4)/(r2-r4)];
-k\[Theta]=0;
-\[CapitalUpsilon]r=(Pi Sqrt[2(r2-r4)])/(2EllipticK[kr^2]);
-\[CapitalUpsilon]\[Theta]=( L Sqrt[\[Epsilon]0zp]);
-
-hM = ((r3-M))/((r2-M));
-
-hr=1;
-
-(*\[CapitalUpsilon]\[Phi] and \[CapitalGamma] from Appendix B for a=M case*)
-
-\[CapitalUpsilon]\[Phi]= (a (a L (-2 M+r2+r3)+2 En M (-2 r2 r3+M (r2+r3))))/(2 (M-r2) (M-r3)^2)+(a (a L-2 En M^2) (r2-r4) EllipticE[kr^2])/(2 (M-r2) (M-r3) (M-r4) EllipticK[kr^2])-(a (r2-r3) (2 En M (-M^3+M r3 r4-2 r2 r3 r4+M r2 (r3+r4))+a L (3 M^2+r3 r4+r2 (r3+r4)-2 M (r2+r3+r4))) EllipticPi[hM,kr^2])/(2 (M-r2)^2 (M-r3)^2 (M-r4) EllipticK[kr^2])+(2 \[CapitalUpsilon]\[Theta] EllipticPi[zm,k\[Theta]^2])/(\[Pi] Sqrt[\[Epsilon]0zp]);
-
-\[CapitalGamma]=\[Infinity];
-
-<| "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(r\)]\)" -> \[CapitalUpsilon]r,
-   "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Theta]\)]\)" -> Abs[\[CapitalUpsilon]\[Theta]],
-   "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Phi]\)]\)" -> \[CapitalUpsilon]\[Phi],
-   "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(t\)]\)" -> \[CapitalGamma] |>
-]
-
-
-KerrGeoMinoFrequencies[(1|1.),p_,e_,x_]:=Module[{M=1,a=1,En,L,Q,r1,r2,r3,r4,\[Epsilon]0,zm,a2zp,\[Epsilon]0zp,zmOverZp,kr,k\[Theta],\[CapitalUpsilon]r,\[CapitalUpsilon]\[Theta],rp,rm,hr,hM,\[CapitalUpsilon]\[Phi],\[CapitalGamma]},
-
-{En,L,Q} = Values[KerrGeoConstantsOfMotion[a,p,e,x]];
-
-{r1,r2,r3,r4} = KerrGeoRadialRoots[a,p,e,x,En,Q];
-\[Epsilon]0=a^2 (1-En^2)/L^2;
-zm=1-x^2;
-a2zp=(L^2+a^2 (-1+En^2) (-1+zm))/( (-1+En^2) (-1+zm));
-
-\[Epsilon]0zp=-((L^2+a^2 (-1+En^2) (-1+zm))/(L^2 (-1+zm)));
-
-(*zmOverZp=If[a==0,0,zm/((L^2+a^2 (-1+En^2) (-1+zm))/(a^2 (-1+En^2) (-1+zm)))];*)
-zmOverZp=zm/((L^2+a^2 (-1+En^2) (-1+zm))/(a^2 (-1+En^2) (-1+zm)));
-
-
-kr=Sqrt[(r1-r2)/(r1-r3) (r3-r4)/(r2-r4)];(*Eq.(13)*)
-k\[Theta]=Sqrt[zmOverZp];(*Eq.(13)*)
-\[CapitalUpsilon]r=(Pi Sqrt[(1-En^2)(r1-r3)(r2-r4)])/(2EllipticK[kr^2]);(*Eq.(15)*)
-\[CapitalUpsilon]\[Theta]=(Pi L Sqrt[\[Epsilon]0zp])/(2EllipticK[k\[Theta]^2]);(*Eq.(15)*)
-
-hM = ((r1-r2)(r3-M))/((r1-r3)(r2-M));
-
-hr=(r1-r2)/(r1-r3);
-
-(*\[CapitalUpsilon]\[Phi] and \[CapitalGamma] from Appendix B for a=M case*)
-
-\[CapitalUpsilon]\[Phi]= (2\[CapitalUpsilon]\[Theta])/(\[Pi] Sqrt[\[Epsilon]0zp]) EllipticPi[zm, k\[Theta]^2]+ (2 a \[CapitalUpsilon]r)/(\[Pi] Sqrt[(1-En^2)(r1-r3)(r2-r4)]) ((2M En)/(r3-M) (EllipticK[kr^2] - (r2-r3)/(r2-M) EllipticPi[hM,kr^2])+(2M^2 En-a L)/(2(r3-M)^2) ((2-((r1-r3)(r2-r3))/((r1-M)(r2-M)))EllipticK[kr^2] + ((r1-r3)(r2-r4)(r3-M))/((r1-M)(r2-M)(r4-M)) EllipticE[kr^2]+(r2-r3)/(r2-M) ((r1-r3)/(r1-M)+(r2-r3)/(r2-M)+(r4-r3)/(r4-M)-4)EllipticPi[hM, kr^2]));
-
-\[CapitalGamma]=4M^2 En+(2a^2 En a2zp \[CapitalUpsilon]\[Theta])/(\[Pi] L Sqrt[\[Epsilon]0zp]) (EllipticK[k\[Theta]^2]-EllipticE[k\[Theta]^2]) + (2 \[CapitalUpsilon]r)/(\[Pi] Sqrt[(1-En^2)(r1-r3)(r2-r4)]) (En/2 ((r3(r1+r2+r3)-r1 r2)EllipticK[kr^2]+(r2-r3)(r1+r2+r3+r4)EllipticPi[hr,kr^2]+(r1-r3)(r2-r4)EllipticE[kr^2])+2M En(r3 EllipticK[kr^2]+(r2-r3)EllipticPi[hr,kr^2]) + (2M(4M^2 En - a L))/(r3-M) (EllipticK[kr^2]-(r2-r3)/(r2-M) EllipticPi[hM,kr^2])+(M^2 (2M^2 En-a L ))/(r3-M)^2 ((2-((r1-r3)(r2-r3))/((r1-M)(r2-M)))EllipticK[kr^2]+((r1-r3)(r2-r4)(r3-M))/((r1-M)(r2-M)(r4-M)) EllipticE[kr^2]+(r2-r3)/(r2-M) ((r1-r3)/(r1-M)+(r2-r3)/(r2-M)+(r4-r3)/(r4-M)-4)EllipticPi[hM,kr^2]));
-
-<| "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(r\)]\)" -> \[CapitalUpsilon]r,
-   "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Theta]\)]\)" -> Abs[\[CapitalUpsilon]\[Theta]],
-   "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Phi]\)]\)" -> \[CapitalUpsilon]\[Phi],
-   "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(t\)]\)" -> \[CapitalGamma] |>
 ]
 
 
@@ -307,11 +325,6 @@ Module[{\[Rho]1,\[Rho]2,\[Rho]3,\[Rho]4,zm,zp,T},
 		+(zp^2 EllipticE[k\[Theta]])/((-1+T^2) EllipticK[k\[Theta]])+((\[Rho]2-\[Rho]3) (\[Rho]1+\[Rho]2+\[Rho]3+\[Rho]4) EllipticPi[hr,kr])/(2 EllipticK[kr])
 	]
 ]
-
-
-
-
-
 
 
 KerrGeoProperFrequencies[a_,p_,e_,x_]:=Module[{MinoFreqs,P},

--- a/Kernel/OrbitalFrequencies.m
+++ b/Kernel/OrbitalFrequencies.m
@@ -4,7 +4,7 @@
 (*OrbitalFrequencies subpackage of KerrGeodesics*)
 
 
-(* ::Section::Closed:: *)
+(* ::Section:: *)
 (*Define usage for public functions*)
 
 
@@ -16,7 +16,7 @@ KerrGeoFrequencies::usage = "KerrGeoFrequencies[a, p, e, x] returns the orbital 
 Begin["`Private`"];
 
 
-(* ::Section::Closed:: *)
+(* ::Section:: *)
 (*Roots of the radial and polar equations*)
 
 
@@ -37,15 +37,13 @@ r4=AB/r3;
 ]
 
 
-KerrGeoRadialRoots[a_, p_, e_/;e==1, x_, En1_:Null,Q1_:Null] := Module[{M=1,En=En1,Q=Q1,r1,r2,r3,r4,zm,\[Rho]2},
+KerrGeoRadialRoots[a_, p_, e_/;e==1, x_, En1_:Null,Q1_:Null] := Module[{M=1,En=En1,Q=Q1,r1,r2,r3,r4,\[Rho]2},
 r1=\[Infinity];
 r2=\[Rho]2=p/(1+e);
 
-zm = Sqrt[1-x^2];
-r3=1/4 (1-2 \[Rho]2+1/(a^2 zm^2+(-2+\[Rho]2) \[Rho]2)^2 (-a^4 (zm^4-2 zm^2 \[Rho]2)-4 Sqrt[2] a \[Rho]2 Sqrt[(1-zm^2) \[Rho]2 (a^2+(-2+\[Rho]2) \[Rho]2) (a^2 zm^2+\[Rho]2^2)]+(-2+\[Rho]2) \[Rho]2^2 (2+\[Rho]2 (-1+2 \[Rho]2))+2 a^2 \[Rho]2 (\[Rho]2 (2+\[Rho]2)+zm^2 (2+(-5+\[Rho]2) \[Rho]2)))+
-\[Sqrt]((-8 a^2 zm^2  (-2 a \[Rho]2 Sqrt[1-zm^2]+Sqrt[2] Sqrt[\[Rho]2 (a^2+(-2+\[Rho]2) \[Rho]2) (a^2 zm^2+\[Rho]2^2)])^2)/(\[Rho]2 (a^2 zm^2+(-2+\[Rho]2) \[Rho]2)^2)+(4 \[Rho]2^2 (a^4 zm^2 (-1+zm^2)-2 (-2+\[Rho]2) \[Rho]2^2+a^2 \[Rho]2 (-2+(-1+zm^2) \[Rho]2)+2 Sqrt[2] a Sqrt[(1-zm^2) \[Rho]2 (a^2+(-2+\[Rho]2) \[Rho]2) (a^2 zm^2+\[Rho]2^2)])^2)/(a^2 zm^2+(-2+\[Rho]2) \[Rho]2)^4));
-r4=1/4 (1-2 \[Rho]2+1/(a^2 zm^2+(-2+\[Rho]2) \[Rho]2)^2 (-a^4 (zm^4-2 zm^2 \[Rho]2)-4 Sqrt[2] a \[Rho]2 Sqrt[-(-1+zm^2) \[Rho]2 (a^2+(-2+\[Rho]2) \[Rho]2) (a^2 zm^2+\[Rho]2^2)]+(-2+\[Rho]2) \[Rho]2^2 (2+\[Rho]2 (-1+2 \[Rho]2))+2 a^2 \[Rho]2 (\[Rho]2 (2+\[Rho]2)+zm^2 (2+(-5+\[Rho]2) \[Rho]2)))-
-\[Sqrt](1/\[Rho]2((-8 a^2 zm^2  (-2 a \[Rho]2 Sqrt[1-zm^2]+Sqrt[2] Sqrt[\[Rho]2 (a^2+(-2+\[Rho]2) \[Rho]2) (a^2 zm^2+\[Rho]2^2)])^2)/(a^2 zm^2+(-2+\[Rho]2) \[Rho]2)^2+(4 \[Rho]2^3 (a^4 (zm^2-zm^4)+2 (-2+\[Rho]2) \[Rho]2^2+a^2 \[Rho]2 (2+\[Rho]2-zm^2 \[Rho]2)-2 Sqrt[2] a Sqrt[-(-1+zm^2) \[Rho]2 (a^2+(-2+\[Rho]2) \[Rho]2) (a^2 zm^2+\[Rho]2^2)])^2)/(a^2 zm^2+(-2+\[Rho]2) \[Rho]2)^4)));
+r3=1/4 (1-2 \[Rho]2+Sqrt[(8 a^2 (-1+x^2) (-2 a x \[Rho]2+Sqrt[2] Sqrt[\[Rho]2 (a^2+(-2+\[Rho]2) \[Rho]2) (-a^2 (-1+x^2)+\[Rho]2^2)])^2)/(\[Rho]2 (a^2 (-1+x^2)-(-2+\[Rho]2) \[Rho]2)^2)+(4 \[Rho]2^2 (a^4 (x^2-x^4)+2 (-2+\[Rho]2) \[Rho]2^2+a^2 \[Rho]2 (2+x^2 \[Rho]2)-2 Sqrt[2] a x Sqrt[\[Rho]2 (a^2+(-2+\[Rho]2) \[Rho]2) (-a^2 (-1+x^2)+\[Rho]2^2)])^2)/(a^2 (-1+x^2)-(-2+\[Rho]2) \[Rho]2)^4]+(-a^4 (-1+x^2) (-1+x^2+2 \[Rho]2)-4 Sqrt[2] a x \[Rho]2 Sqrt[\[Rho]2 (a^2+(-2+\[Rho]2) \[Rho]2) (-a^2 (-1+x^2)+\[Rho]2^2)]+\[Rho]2^2 (-4+4 \[Rho]2-5 \[Rho]2^2+2 \[Rho]2^3)-2 a^2 \[Rho]2 (-2+3 \[Rho]2-2 \[Rho]2^2+x^2 (2-5 \[Rho]2+\[Rho]2^2)))/(a^2 (-1+x^2)-(-2+\[Rho]2) \[Rho]2)^2);
+
+r4=1/4 (1-2 \[Rho]2-Sqrt[(8 a^2 (-1+x^2) (-2 a x \[Rho]2+Sqrt[2] Sqrt[\[Rho]2 (a^2+(-2+\[Rho]2) \[Rho]2) (-a^2 (-1+x^2)+\[Rho]2^2)])^2)/(\[Rho]2 (a^2 (-1+x^2)-(-2+\[Rho]2) \[Rho]2)^2)+(4 \[Rho]2^2 (a^4 (x^2-x^4)+2 (-2+\[Rho]2) \[Rho]2^2+a^2 \[Rho]2 (2+x^2 \[Rho]2)-2 Sqrt[2] a x Sqrt[\[Rho]2 (a^2+(-2+\[Rho]2) \[Rho]2) (-a^2 (-1+x^2)+\[Rho]2^2)])^2)/(a^2 (-1+x^2)-(-2+\[Rho]2) \[Rho]2)^4]+(-a^4 (-1+x^2) (-1+x^2+2 \[Rho]2)-4 Sqrt[2] a x \[Rho]2 Sqrt[\[Rho]2 (a^2+(-2+\[Rho]2) \[Rho]2) (-a^2 (-1+x^2)+\[Rho]2^2)]+\[Rho]2^2 (-4+4 \[Rho]2-5 \[Rho]2^2+2 \[Rho]2^3)-2 a^2 \[Rho]2 (-2+3 \[Rho]2-2 \[Rho]2^2+x^2 (2-5 \[Rho]2+\[Rho]2^2)))/(a^2 (-1+x^2)-(-2+\[Rho]2) \[Rho]2)^2);
 
 {r1,r2,r3,r4}
 
@@ -64,7 +62,7 @@ KerrGeoPolarRoots[a_, p_, e_, x_] := Module[{En,L,Q,zm,zp},
 ]
 
 
-(* ::Section::Closed:: *)
+(* ::Section:: *)
 (*Orbital Frequencies*)
 
 
@@ -72,7 +70,7 @@ KerrGeoPolarRoots[a_, p_, e_, x_] := Module[{En,L,Q,zm,zp},
 (*Orbital frequency calculations from Fujita and Hikida, Class. Quantum Grav .26 (2009) 135002, arXiv:0906.1420*)
 
 
-(* ::Subsection::Closed:: *)
+(* ::Subsection:: *)
 (*Schwarzschild*)
 
 
@@ -80,21 +78,21 @@ KerrGeoMinoFrequencies[a_?PossibleZeroQ, p_, e_?PossibleZeroQ,x_] :=
  <| "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(r\)]\)" -> Sqrt[((-6+p) p)/(-3+p)],
     "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Theta]\)]\)" -> p Sqrt[1/((-3+p) x^2)] x,
     "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Phi]\)]\)" -> (p x)/Sqrt[(-3+p) x^2],
-    "\[CapitalGamma]" -> Sqrt[p^5/(-3+p)] |>;
+    "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(t\)]\)"  -> Sqrt[p^5/(-3+p)] |>;
 
 
 KerrGeoMinoFrequencies[a_?PossibleZeroQ, p_,e_,x_] :=
  <| "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(r\)]\)" -> (Sqrt[-((p (-6+2 e+p))/(3+e^2-p))] \[Pi])/(2 EllipticK[(4 e)/(-6+2 e+p)]),
     "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Theta]\)]\)" -> p/Sqrt[-3-e^2+p],
     "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Phi]\)]\)" -> (p x)/(Sqrt[-3-e^2+p] Abs[x]),
-    "\[CapitalGamma]" -> 1/2 Sqrt[(-4 e^2+(-2+p)^2)/(p (-3-e^2+p))] (8+1/((-4+p)^2 EllipticK[(4 e)/(-6+2 e+p)]) (-(((-4+p) p^2 (-6+2 e+p) EllipticE[(4 e)/(-6+2 e+p)])/(-1+e^2))+(p^2 (28+4 e^2-12 p+p^2) EllipticK[(4 e)/(-6+2 e+p)])/(-1+e^2)-(2 (6+2 e-p) (3+e^2-p) p^2 EllipticPi[(2 e (-4+p))/((1+e) (-6+2 e+p)),(4 e)/(-6+2 e+p)])/((-1+e) (1+e)^2)+(4 (-4+p) p (2 (1+e) EllipticK[(4 e)/(-6+2 e+p)]+(-6-2 e+p) EllipticPi[(2 e (-4+p))/((1+e) (-6+2 e+p)),(4 e)/(-6+2 e+p)]))/(1+e)+2 (-4+p)^2 ((-4+p) EllipticK[(4 e)/(-6+2 e+p)]-((6+2 e-p) p EllipticPi[(16 e)/(12+8 e-4 e^2-8 p+p^2),(4 e)/(-6+2 e+p)])/(2+2 e-p)))) |>;
+    "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(t\)]\)" -> 1/2 Sqrt[(-4 e^2+(-2+p)^2)/(p (-3-e^2+p))] (8+1/((-4+p)^2 EllipticK[(4 e)/(-6+2 e+p)]) (-(((-4+p) p^2 (-6+2 e+p) EllipticE[(4 e)/(-6+2 e+p)])/(-1+e^2))+(p^2 (28+4 e^2-12 p+p^2) EllipticK[(4 e)/(-6+2 e+p)])/(-1+e^2)-(2 (6+2 e-p) (3+e^2-p) p^2 EllipticPi[(2 e (-4+p))/((1+e) (-6+2 e+p)),(4 e)/(-6+2 e+p)])/((-1+e) (1+e)^2)+(4 (-4+p) p (2 (1+e) EllipticK[(4 e)/(-6+2 e+p)]+(-6-2 e+p) EllipticPi[(2 e (-4+p))/((1+e) (-6+2 e+p)),(4 e)/(-6+2 e+p)]))/(1+e)+2 (-4+p)^2 ((-4+p) EllipticK[(4 e)/(-6+2 e+p)]-((6+2 e-p) p EllipticPi[(16 e)/(12+8 e-4 e^2-8 p+p^2),(4 e)/(-6+2 e+p)])/(2+2 e-p)))) |>;
 
 
-KerrGeoMinoFrequencies[0|0., p_,e_/;e==1,x_] :=
+KerrGeoMinoFrequencies[a_?PossibleZeroQ, p_,e_/;e==1,x_] :=
  <| "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(r\)]\)" -> (Sqrt[-((p (-6+2 e+p))/(3+e^2-p))] \[Pi])/(2 EllipticK[(4 e)/(-6+2 e+p)]),
     "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Theta]\)]\)" -> p/Sqrt[-3-e^2+p],
     "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Phi]\)]\)" -> (p x)/(Sqrt[-3-e^2+p] Abs[x]),
-    "\[CapitalGamma]" -> \[Infinity] |>;
+    "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(t\)]\)"  -> \[Infinity] |>;
 
 
 KerrGeoBoyerLindquistFrequencies[a_?PossibleZeroQ, p_, e_?PossibleZeroQ,x_] :=
@@ -103,14 +101,20 @@ KerrGeoBoyerLindquistFrequencies[a_?PossibleZeroQ, p_, e_?PossibleZeroQ,x_] :=
     "\!\(\*SubscriptBox[\(\[CapitalOmega]\), \(\[Phi]\)]\)" -> (p x)/Sqrt[p^5 x^2] |>;
 
 
+KerrGeoProperFrequencyFactor[_,p_,e_/;e==1,x_]:=\[Infinity]
+
+
 KerrGeoProperFrequencyFactor[a_?PossibleZeroQ, p_, e_?PossibleZeroQ,x_]:=p^2
 
 
-KerrGeoProperFrequencyFactor[0|0. ,p_,e_,x_]:=(p^2 ((1+e) (28+4 e^2+(-12+p) p)-((1+e) (-4+p) (-6+2 e+p) EllipticE[(4 e)/(-6+2 e+p)]+2 (6+2 e-p) (3+e^2-p) EllipticPi[(2 e (-4+p))/((1+e) (-6+2 e+p)),(4 e)/(-6+2 e+p)])/EllipticK[(4 e)/(-6+2 e+p)]))/(2 (-1+e) (1+e)^2 (-4+p)^2)
+KerrGeoProperFrequencyFactor[a_?PossibleZeroQ ,p_,e_,x_]:=(p^2 ((1+e) (28+4 e^2+(-12+p) p)-((1+e) (-4+p) (-6+2 e+p) EllipticE[(4 e)/(-6+2 e+p)]+2 (6+2 e-p) (3+e^2-p) EllipticPi[(2 e (-4+p))/((1+e) (-6+2 e+p)),(4 e)/(-6+2 e+p)])/EllipticK[(4 e)/(-6+2 e+p)]))/(2 (-1+e) (1+e)^2 (-4+p)^2)
 
 
-(* ::Subsection::Closed:: *)
+(* ::Subsection:: *)
 (*Kerr*)
+
+
+KerrGeoMinoFrequencies[a_?Negative,p_,e_,x_]:=<|"\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(r\)]\)"->1,"\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Theta]\)]\)"->1,"\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Phi]\)]\)"->-1,"\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(t\)]\)"->1|>KerrGeoMinoFrequencies[-a,p,e,-x]
 
 
 KerrGeoMinoFrequencies[a_,p_,e_?PossibleZeroQ, 1] := Module[{\[CapitalUpsilon]r, \[CapitalUpsilon]\[Phi], \[CapitalUpsilon]\[Theta], \[CapitalGamma]},
@@ -178,11 +182,11 @@ zm=1-x^2;
 \[Epsilon]0zp=-(1/((-1+zm)));
 
 (*zmOverZp=If[a==0,0,zm/((L^2+a^2 (-1+En^2) (-1+zm))/(a^2 (-1+En^2) (-1+zm)))];*)
-zmOverZp=(-1+En^2)zm/((L^2+a^2 (-1+En^2) (-1+zm))/(a^2  (-1+zm)));
+(*zmOverZp=(-1+En^2)zm/((L^2+a^2 (-1+En^2) (-1+zm))/(a^2  (-1+zm)));*)
 
 
 kr=Sqrt[(r3-r4)/(r2-r4)];
-k\[Theta]=Sqrt[zmOverZp];(*Eq.(13)*)
+k\[Theta]=0;(*Eq.(13)*)
 \[CapitalUpsilon]r=(Pi Sqrt[2(r2-r4)])/(2EllipticK[kr^2]);
 \[CapitalUpsilon]\[Theta]=( L Sqrt[\[Epsilon]0zp]);
 
@@ -203,6 +207,43 @@ hm=((r3-rm))/((r2-rm));
     "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Phi]\)]\)" -> \[CapitalUpsilon]\[Phi],
     "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(t\)]\)" -> \[CapitalGamma] |>
 
+]
+
+
+KerrGeoMinoFrequencies[(1|1.),p_,e_/;e==1,x_]:=Module[{M=1,a=1,En,L,Q,r1,r2,r3,r4,\[Epsilon]0,zm,a2zp,\[Epsilon]0zp,zmOverZp,kr,k\[Theta],\[CapitalUpsilon]r,\[CapitalUpsilon]\[Theta],rp,rm,hr,hM,\[CapitalUpsilon]\[Phi],\[CapitalGamma]},
+
+{En,L,Q} = Values[KerrGeoConstantsOfMotion[a,p,e,x]];
+
+{r1,r2,r3,r4} = KerrGeoRadialRoots[a,p,e,x,En,Q];
+\[Epsilon]0=a^2 (1-En^2)/L^2;
+zm=1-x^2;
+(*a2zp=(L^2+a^2 (-1+En^2) (-1+zm))/( (-1+En^2) (-1+zm));*)
+
+\[Epsilon]0zp=-(1/((-1+zm)));
+
+(*zmOverZp=If[a==0,0,zm/((L^2+a^2 (-1+En^2) (-1+zm))/(a^2 (-1+En^2) (-1+zm)))];*)
+(*zmOverZp=(-1+En^2)zm/((L^2+a^2 (-1+En^2) (-1+zm))/(a^2  (-1+zm)));
+*)
+
+kr=Sqrt[(r3-r4)/(r2-r4)];
+k\[Theta]=0;
+\[CapitalUpsilon]r=(Pi Sqrt[2(r2-r4)])/(2EllipticK[kr^2]);
+\[CapitalUpsilon]\[Theta]=( L Sqrt[\[Epsilon]0zp]);
+
+hM = ((r3-M))/((r2-M));
+
+hr=1;
+
+(*\[CapitalUpsilon]\[Phi] and \[CapitalGamma] from Appendix B for a=M case*)
+
+\[CapitalUpsilon]\[Phi]= (a (a L (-2 M+r2+r3)+2 En M (-2 r2 r3+M (r2+r3))))/(2 (M-r2) (M-r3)^2)+(a (a L-2 En M^2) (r2-r4) EllipticE[kr^2])/(2 (M-r2) (M-r3) (M-r4) EllipticK[kr^2])-(a (r2-r3) (2 En M (-M^3+M r3 r4-2 r2 r3 r4+M r2 (r3+r4))+a L (3 M^2+r3 r4+r2 (r3+r4)-2 M (r2+r3+r4))) EllipticPi[hM,kr^2])/(2 (M-r2)^2 (M-r3)^2 (M-r4) EllipticK[kr^2])+(2 \[CapitalUpsilon]\[Theta] EllipticPi[zm,k\[Theta]^2])/(\[Pi] Sqrt[\[Epsilon]0zp]);
+
+\[CapitalGamma]=\[Infinity];
+
+<| "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(r\)]\)" -> \[CapitalUpsilon]r,
+   "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Theta]\)]\)" -> Abs[\[CapitalUpsilon]\[Theta]],
+   "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Phi]\)]\)" -> \[CapitalUpsilon]\[Phi],
+   "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(t\)]\)" -> \[CapitalGamma] |>
 ]
 
 
@@ -269,6 +310,10 @@ Module[{\[Rho]1,\[Rho]2,\[Rho]3,\[Rho]4,zm,zp,T},
 
 
 
+
+
+
+
 KerrGeoProperFrequencies[a_,p_,e_,x_]:=Module[{MinoFreqs,P},
 	MinoFreqs = KerrGeoMinoFrequencies[a,p,e,x];
 	P=KerrGeoProperFrequencyFactor[a,p,e,x];
@@ -276,7 +321,12 @@ KerrGeoProperFrequencies[a_,p_,e_,x_]:=Module[{MinoFreqs,P},
 ]
 
 
-(* ::Subsection::Closed:: *)
+KerrGeoProperFrequencies[a_,p_,e_/;e==1,x_]:=Module[{MinoFreqs,P},
+	<|"\!\(\*SubscriptBox[\(\[Omega]\), \(r\)]\)"-> 0, "\!\(\*SubscriptBox[\(\[Omega]\), \(\[Theta]\)]\)"-> 0, "\!\(\*SubscriptBox[\(\[Omega]\), \(\[Phi]\)]\)"-> 0 |>
+]
+
+
+(* ::Subsection:: *)
 (*Generic function for choosing between frequencies w.r.t different time coordinates*)
 
 

--- a/Kernel/OrbitalFrequencies.m
+++ b/Kernel/OrbitalFrequencies.m
@@ -269,52 +269,6 @@ KerrGeoMinoFrequencyt\[Theta][a_,p_,e_,x_/;x^2==1,{En_,L_,Q_},{zp_,zm_}]:=Module
 
 
 (* ::Subsubsection::Closed:: *)
-(*Marginally bound (e = 1)*)
-
-
-KerrGeoMinoFrequencies[a_,p_,e_/;e==1,x_]:=Module[{M=1,En,L,Q,r1,r2,r3,r4,\[Epsilon]0,zm,a2zp,\[Epsilon]0zp,zmOverZp,kr,k\[Theta],\[CapitalUpsilon]r,\[CapitalUpsilon]\[Theta],rp,rm,hr,hp,hm,\[CapitalUpsilon]\[Phi],\[CapitalGamma]},
-{En,L,Q} = Values[KerrGeoConstantsOfMotion[a,p,e,x]];
-
-{r1,r2,r3,r4} = KerrGeoRadialRoots[a,p,e,x,En,Q];
-\[Epsilon]0=a^2 (1-En^2)/L^2;
-zm=1-x^2;
-(*a2zp=(L^2+a^2 (-1+En^2) (-1+zm))/( (-1+En^2) (-1+zm));*)
-
-\[Epsilon]0zp=-(1/((-1+zm)));
-
-(*zmOverZp=If[a==0,0,zm/((L^2+a^2 (-1+En^2) (-1+zm))/(a^2 (-1+En^2) (-1+zm)))];*)
-zmOverZp=(-1+En^2)zm/((L^2+a^2 (-1+En^2) (-1+zm))/(a^2  (-1+zm)));
-
-
-kr=Sqrt[(r3-r4)/(r2-r4)];
-k\[Theta]=Sqrt[zmOverZp];(*Eq.(13)*)
-\[CapitalUpsilon]r=(Pi Sqrt[2(r2-r4)])/(2EllipticK[kr^2]);
-\[CapitalUpsilon]\[Theta]=( L Sqrt[\[Epsilon]0zp]);
-
-rp=M+Sqrt[M^2-a^2];
-rm=M-Sqrt[M^2-a^2];
-hr=1;
-hp=((r3-rp))/((r2-rp));
-hm=((r3-rm))/((r2-rm));
-
-(*Eq. (21)*)
-\[CapitalUpsilon]\[Phi]=  (2\[CapitalUpsilon]\[Theta])/(Pi Sqrt[\[Epsilon]0zp]) EllipticPi[zm,k\[Theta]^2]+a/(2Sqrt[1-a^2]) ((2  rp-a L)/(r3-rp) (1-(r2-r3)/(r2-rp) EllipticPi[hp,kr^2]/EllipticK[kr^2])-(2  rm-a L)/(r3-rm) (1-(r2-r3)/(r2-rm) EllipticPi[hm,kr^2]/EllipticK[kr^2]));
-
-\[CapitalGamma] = \[Infinity];
-
-
- <| "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(r\)]\)" -> \[CapitalUpsilon]r,
-    "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Theta]\)]\)" -> Abs[\[CapitalUpsilon]\[Theta]],
-    "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Phi]\)]\)" -> \[CapitalUpsilon]\[Phi],
-    "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(t\)]\)" -> \[CapitalGamma] |>
-
-]
-
-
-
-
-
-(* ::Subsubsection::Closed:: *)
 (*KerrGeoMinoFrequencies*)
 
 
@@ -420,7 +374,7 @@ If[OptionValue["Time"]=="Proper",Return[KerrGeoProperFrequencies[a,p,e,x][[1;;3]
 ]
 
 
-(* ::Section:: *)
+(* ::Section::Closed:: *)
 (*Close the package*)
 
 

--- a/Kernel/ParallelTransport.m
+++ b/Kernel/ParallelTransport.m
@@ -22,6 +22,14 @@ KerrParallelTransportFrameFunction::usage = "KerrParallelTransportFrameFunction[
 Begin["`Private`"];
 
 
+(* ::Subsection::Closed:: *)
+(*Error messages*)
+
+
+KerrParallelTransportFrame::general = "`1`"
+KerrParallelTransportFrame::parametrization = "Parametrization error: `1`"
+
+
 (* ::Section::Closed:: *)
 (*Kerr*)
 
@@ -245,14 +253,14 @@ KerrParallelTransportFrame[a_,p_,e_,x_, initPhases:{_,_,_,_,_}:{0,0,0,0,0},Optio
 method = OptionValue["Method"];
 param = OptionValue["Parametrization"];
 
-If[param =!= "Mino", Print["Only Mino time parametrization has been implemented for parallel transport."];Return[];];
-If[method =!= "Analytic", Print["Only analytic method has been implemented for parallel transport."];Return[];];
+If[param =!= "Mino", Message[KerrParallelTransportFrame::parametrization, "Only Mino time parametrization has been implemented for parallel transport."]; Return[];];
+If[method =!= "Analytic", Message[KerrParallelTransportFrame::general, "Only Analytic method has been implemented for parallel transport."]; Return[];];
 
 If[method == "Analytic",
 	If[param == "Mino", Return[KerrParallelTransportFrameMino[a, p, e, x, initPhases]]];
 ];
 
-Print["Unrecognized method: " <> method];
+Message[KerrParallelTransportFrame::general, "Method: " <> method <> "is not one of {Analytic}."];
 
 ]
 

--- a/Kernel/SpecialOrbits.m
+++ b/Kernel/SpecialOrbits.m
@@ -65,7 +65,7 @@ Begin["`Private`"];
 (*Schwarzschild ISCO is at r=6M*)
 
 
-KerrGeoISCO[(0|0.),x_]:=6
+KerrGeoISCO[_?PossibleZeroQ,x_]:=6
 
 
 (* ::Text:: *)
@@ -75,11 +75,11 @@ KerrGeoISCO[(0|0.),x_]:=6
 KerrGeoISCO[a_,x_/;x^2==1]:=Module[{M=1,Z1,Z2},
 	Z1=1+(1-a^2/M^2)^(1/3) ((1+a/M)^(1/3)+(1-a/M)^(1/3));
 	Z2=(3a^2/M^2 + Z1^2)^(1/2);
-	M(3+Z2-x ((3-Z1)(3+Z1+2Z2)/x^2)^(1/2))
+	M(3+Z2-x a ((3-Z1)(3+Z1+2Z2)/(a x)^2)^(1/2))
 ];
 
 
-(* ::Section::Closed:: *)
+(* ::Section:: *)
 (*Photon Sphere*)
 
 
@@ -87,7 +87,7 @@ KerrGeoISCO[a_,x_/;x^2==1]:=Module[{M=1,Z1,Z2},
 (*The photon sphere is at 3M for all radii in Schwarzschild*)
 
 
-KerrGeoPhotonSphereRadius[(0|0.),x_]:=3
+KerrGeoPhotonSphereRadius[_?PossibleZeroQ,x_]:=3
 
 
 (* ::Text:: *)
@@ -102,7 +102,7 @@ KerrGeoPhotonSphereRadius[a_,-1]:=2(1+Cos[2/3 ArcCos[a]])
 (*For polar orbits the radius was given by E. Teo, General Relativity and Gravitation, v. 35, Issue 11, p. 1909-1926 (2003), Eq. (14)*)
 
 
-KerrGeoPhotonSphereRadius[a_,(0|0.)]:=1+2Sqrt[1-1/3 a^2]Cos[1/3 ArcCos[(1-a^2)/(1-1/3 a^2)^(3/2)]]
+KerrGeoPhotonSphereRadius[a_,_?PossibleZeroQ]:=1+2Sqrt[1-1/3 a^2]Cos[1/3 ArcCos[(1-a^2)/(1-1/3 a^2)^(3/2)]]
 
 
 (* ::Text:: *)
@@ -110,6 +110,7 @@ KerrGeoPhotonSphereRadius[a_,(0|0.)]:=1+2Sqrt[1-1/3 a^2]Cos[1/3 ArcCos[(1-a^2)/(
 
 
 KerrGeoPhotonSphereRadius[1,x_]:=If[x < Sqrt[3]-1, 1+Sqrt[2] Sqrt[1-x]-x, 1];
+KerrGeoPhotonSphereRadius[-1,x_]:=KerrGeoPhotonSphereRadius[1,-x]
 
 
 (* ::Text:: *)
@@ -133,11 +134,11 @@ This seems to be fine near the equatorial plane but might not be ideal for incli
 ]
 
 
-(* ::Section::Closed:: *)
+(* ::Section:: *)
 (*Innermost bound spherical orbits (IBSO)*)
 
 
-KerrGeoIBSO[0,x_]:= 4
+KerrGeoIBSO[_?PossibleZeroQ,x_]:= 4
 
 
 (* ::Text:: *)
@@ -175,37 +176,44 @@ KerrGeoIBSO[a1_?NumericQ,x1_?NumericQ]/;(Precision[{a1,x1}]!=\[Infinity])&&(-1<=
 p/.FindRoot[IBSOPoly/.{a->a1,x->x1},{p,KerrGeoIBSO[a1,0],KerrGeoIBSO[a1,-1]},WorkingPrecision->Max[MachinePrecision,prec-1]]];
 
 
-(* ::Section::Closed:: *)
+(* ::Section:: *)
 (*Separatrix*)
+
+
+(* ::Text:: *)
+(*Negative spin*)
+
+
+KerrGeoSeparatrix[a_?Negative,e_,x_]:=KerrGeoSeparatrix[-a,e,-x]
 
 
 (* ::Text:: *)
 (*Schwarzschild*)
 
 
-KerrGeoSeparatrix[0,e_,x_]:= 6+2e;
+KerrGeoSeparatrix[_?PossibleZeroQ,e_,x_]:= 6+2e;
 
 
 (* ::Text:: *)
 (*From Glampedakis and Kennefick arXiv:gr-qc/0203086, for a=M we have Subscript[p, s]=1+e*)
 
 
-KerrGeoSeparatrix[1,e_,1]:= 1+e
+KerrGeoSeparatrix[a_/;a==1,e_,x_/;x==1]:= 1+e
 
 
 (* ::Text:: *)
 (*Polar ISSO in extremal case found from playing around with the equations (see L. Stein and N. Warburton arXiv:1912.07609)*)
 
 
-KerrGeoSeparatrix[1,0,0]:=1+Sqrt[3]+Sqrt[3+2 Sqrt[3]]
-KerrGeoSeparatrix[1,1,0]:=2/3 (3+(54-6Sqrt[33])^(1/3)+(6(9+Sqrt[33]))^(1/3))
+KerrGeoSeparatrix[a_/;a==1,_?PossibleZeroQ,_?PossibleZeroQ]:=1+Sqrt[3]+Sqrt[3+2 Sqrt[3]]
+KerrGeoSeparatrix[a_/;a==1,e_/;e==1,_?PossibleZeroQ]:=2/3 (3+(54-6Sqrt[33])^(1/3)+(6(9+Sqrt[33]))^(1/3))
 
 
 (* ::Text:: *)
 (*For e=1 the Subscript[p, s] is at 2 Subscript[r, ibso]*)
 
 
-KerrGeoSeparatrix[a_,1,x_]:=2KerrGeoIBSO[a,x]
+KerrGeoSeparatrix[a_,e_/;e==1,x_]:=2KerrGeoIBSO[a,x]
 
 
 (* ::Text:: *)


### PR DESCRIPTION
This contains a number of fixes to the behaviour of the constants of motion and frequencies for retrograde and negative spin orbits. All behaviour should now be conistent, including most (all?) edge cases.