### PR TITLE
Add more finding options to KerrGeoFindResonance

### DIFF
--- a/Kernel/SpecialOrbits.m
+++ b/Kernel/SpecialOrbits.m
@@ -668,7 +668,7 @@ Module[{S, P, r1, r2, r3, r4, EnSquared, Q, kr, k\[Theta], factor1, factor2, rPl
 ];
 
 
-(* ::Subsubsection::Closed:: *)
+(* ::Subsubsection:: *)
 (*Given (a,e,x) and Subscript[\[CapitalOmega], r]/Subscript[\[CapitalOmega], \[Phi]]= Subscript[\[Beta], r]/Subscript[\[Beta], \[Phi]] find p*)
 
 
@@ -705,7 +705,7 @@ Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest},
 	If[pg==Infinity,pg=$MachinePrecision];
 	
 	If[pg==$MachinePrecision,
-		Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar},StepMonitor:>Print[pp]]],
+		Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar}]],
 		Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar},PrecisionGoal->pg,WorkingPrecision->pg]],
 		Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar},PrecisionGoal->pg,WorkingPrecision->pg]]
 	]
@@ -826,7 +826,7 @@ Module[{pg,rtt,argpg,resonantEqn,x0Test, x1Test, x0Test1,x0Test2,x1Test1,x1Test2
 (*Same as those of r\[Theta]-resonance*)
 
 
-(* ::Subsubsection:: *)
+(* ::Subsubsection::Closed:: *)
 (*Useful functions for root-finding*)
 
 

--- a/Kernel/SpecialOrbits.m
+++ b/Kernel/SpecialOrbits.m
@@ -375,7 +375,7 @@ Return[pSep+10^(-5)];
 (*	- Root finding methods are based on those described in Sec.  VE*)
 
 
-(* ::Subsubsection::Closed:: *)
+(* ::Subsubsection:: *)
 (*Testing functions*)
 
 
@@ -525,7 +525,7 @@ Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest,pSep},
 ];
 
 
-(* ::Subsubsection:: *)
+(* ::Subsubsection::Closed:: *)
 (*Given (a,p,x) and Subscript[\[CapitalOmega], r]/Subscript[\[CapitalOmega], \[Theta]]= Subscript[\[Beta], r]/Subscript[\[Beta], \[Theta]] find e*)
 
 
@@ -569,7 +569,7 @@ Module[{pg,argpg,resonantEqn,e0Test,e1Test,eGuess,ee,ratio},
 ];
 
 
-(* ::Subsubsection:: *)
+(* ::Subsubsection::Closed:: *)
 (*Given (a,p,e) and Subscript[\[CapitalOmega], r]/Subscript[\[CapitalOmega], \[Theta]]= Subscript[\[Beta], r]/Subscript[\[Beta], \[Theta]] find x*)
 
 
@@ -724,7 +724,7 @@ Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest, pSep},
 ];
 
 
-(* ::Subsubsection:: *)
+(* ::Subsubsection::Closed:: *)
 (*Given (a,p,x) and Subscript[\[CapitalOmega], r]/Subscript[\[CapitalOmega], \[Phi]]= Subscript[\[Beta], r]/Subscript[\[Beta], \[Phi]] find e*)
 
 
@@ -775,7 +775,7 @@ Module[{pg,argpg,resonantEqn,e0Test,e1Test,eGuess,ee,ratio},
 ];
 
 
-(* ::Subsubsection:: *)
+(* ::Subsubsection::Closed:: *)
 (*Given (a,p,e) and Subscript[\[CapitalOmega], r]/Subscript[\[CapitalOmega], \[Phi]]= Subscript[\[Beta], r]/Subscript[\[Beta], \[Phi]] find x*)
 
 
@@ -890,7 +890,7 @@ Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest,pSep},
 ];
 
 
-(* ::Subsubsection:: *)
+(* ::Subsubsection::Closed:: *)
 (*Given (a,p,x) and Subscript[\[CapitalOmega], \[Phi]]/Subscript[\[CapitalOmega], \[Theta]]= Subscript[\[Beta], \[Phi]]/Subscript[\[Beta], \[Theta]] find e*)
 
 
@@ -941,7 +941,7 @@ Module[{pg,argpg,resonantEqn,e0Test,e1Test,eGuess,ee,ratio},
 ];
 
 
-(* ::Subsubsection:: *)
+(* ::Subsubsection::Closed:: *)
 (*Given (a,p,e) and Subscript[\[CapitalOmega], \[Theta]]/Subscript[\[CapitalOmega], \[Phi]]= Subscript[\[Beta], \[Theta]]/Subscript[\[Beta], \[Phi]] find x*)
 
 
@@ -965,7 +965,7 @@ Module[{pg,argpg,resonantEqn,x0Test, x1Test,xGuess,xx,ratio},
 	If[ratio>1 && (p<x1Test||x0Test<p), Message[KerrGeoFindResonance::noresonance, x1Test, x0Test]; Abort[];];
 	If[ratio<1 && (p<x0Test||x1Test<p), Message[KerrGeoFindResonance::noresonance, x0Test, x1Test]; Abort[];];
 	If[p==x0Test,Return[0]];
-	If[p==x1Test,Return[Sign[ratio]]];
+	If[p==x1Test,Return[Sign[ratio-1]]];
 	xGuess=Sign[ratio-1](p-x0Test)/(x1Test-x0Test);
 
 	(* Resonant condition defined by the equation below *)
@@ -1007,7 +1007,7 @@ Module[{pg,argpg,resonantEqn,x0Test, x1Test,xGuess,xx,ratio},
 (*Use those of double resonances*)
 
 
-(* ::Subsubsection::Closed:: *)
+(* ::Subsubsection:: *)
 (*Given (a,e,\[Beta]r,\[Beta]\[Theta]) find (\[Beta]rmin, \[Beta]rmax)*)
 
 
@@ -1019,9 +1019,9 @@ Module[{pg,argpg,resonantEqnr\[Theta],resonantEqnr\[Phi],p0Test,p1Test,r\[Theta]
 	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidXQ[x]||Not@ValidResIntQ[0,\[Beta]\[Theta],\[Beta]\[Phi]],Abort[]];
 	\[Phi]\[Theta]ratio=\[Beta]\[Phi]/\[Beta]\[Theta];
 	p0Test=KerrGeoOrbitPhiThetaResonantP[a, e, 0, {\[Beta]\[Theta], \[Beta]\[Phi]}, opts];
-	p1Test=KerrGeoOrbitPhiThetaResonantP[a, e, Sign[\[Beta]\[Theta]], {\[Beta]\[Theta], \[Beta]\[Phi]}, opts];
-	r\[Theta]ratio0=Sign[\[Beta]\[Theta]]r\[Theta]Ratio[a, p0Test, e, 0];
-	r\[Theta]ratio1=Sign[\[Beta]\[Theta]]r\[Theta]Ratio[a, p1Test, e, Sign[\[Beta]\[Theta]]];
+	p1Test=KerrGeoOrbitPhiThetaResonantP[a, e, Sign[\[Phi]\[Theta]ratio-1], {\[Beta]\[Theta], \[Beta]\[Phi]}, opts];
+	r\[Theta]ratio0=Sign[\[Phi]\[Theta]ratio-1]r\[Theta]Ratio[a, p0Test, e, 0];
+	r\[Theta]ratio1=Sign[\[Phi]\[Theta]ratio-1]r\[Theta]Ratio[a, p1Test, e, Sign[\[Phi]\[Theta]ratio-1]];
 	Sort[{\[Beta]\[Theta] r\[Theta]ratio0, \[Beta]\[Theta] r\[Theta]ratio1}, Less]
 ];
 

--- a/Kernel/SpecialOrbits.m
+++ b/Kernel/SpecialOrbits.m
@@ -8,7 +8,7 @@
 (*Define usage for public functions*)
 
 
-(* ::Section:: *)
+(* ::Section::Closed:: *)
 (*Create Package*)
 
 
@@ -42,14 +42,16 @@ KerrGeoPlungeOrbitQ::usage = "KerrGeoPlungeOrbitQ[a,p,e,x] tests if the orbital 
 
 
 KerrGeoFindResonance::noresonance = "Resonant orbits only occur for semi-latus rectum in range `1` \[LessEqual] p \[LessEqual] `2`"
+KerrGeoFindResonance::noTripleResonance = "Triple Resonant orbits occur for `1` \[LessEqual] r-integer \[LessEqual] `2`, `3` \[LessEqual] \[Theta]-integer \[LessEqual] `4` or `5` \[LessEqual] \[Phi]-integer \[LessEqual] `6`"
 KerrGeoFindResonance::invalida = "Invalid black hole spin parameter. Choose 0 < a \[LessEqual] 1."
 KerrGeoFindResonance::invalide = "Invalid orbital eccentricity. Choose 0 \[LessEqual] e \[LessEqual] 1."
 KerrGeoFindResonance::invalidx = "Invalid orbital inclination. Choose 0 \[LessEqual] |x| \[LessEqual] 1."
-KerrGeoFindResonance::invalidratio = "Invalid resonant integers. Choose \[Beta]r > \[Beta]\[Theta] > 0, \[Beta]r > \[Beta]\[Phi] > 0."
-KerrGeoFindResonance::assocErr = "Association should have 3 keys including both {a,x} and one of {p,e}"
+KerrGeoFindResonance::invalidRatio = "Invalid resonant integers. Choose |\[Beta]r| > |\[Beta]\[Theta]|, |\[Beta]r| > |\[Beta]\[Phi]| and \[Beta]\[Theta]*\[Beta]\[Phi] > 0."
+KerrGeoFindResonance::assocErr = "Association should have 3 keys including both a and two of {p, e, x}"
+KerrGeoFindResonance::assocErrTriple = "Only support association {a, e} for input"
 KerrGeoFindResonance::missing = "Resonaces involving the \[Phi] frequency are not yet implemented"
-KerrGeoFindResonance::prograde = "The solution is prograde: `1`"
-KerrGeoFindResonance::retrograde = "The solution is retrograde: `1`"
+KerrGeoFindResonance::invalidPrograde = "Invalid prograde resonant integers. Choose \[Beta]r/\[Beta]\[Phi] > 0, \[Beta]r/\[Beta]\[Phi] > 0 and \[Beta]\[Theta] < \[Beta]\[Phi]"
+KerrGeoFindResonance::invalidRetrograde = "Invalid retrograde resonant integers. Choose \[Beta]r/\[Beta]\[Phi] < 0, \[Beta]r/\[Beta]\[Phi] < 0 and \[Beta]\[Theta] > \[Beta]\[Phi]"  
 
 
 (* ::Subsection::Closed:: *)
@@ -351,7 +353,7 @@ KerrGeoOrbitType[a_?NumericQ, p_?NumericQ, e_?NumericQ, x_?NumericQ]:=Module[{ou
 (*	- Root finding methods are based on those described in Sec.  VE*)
 
 
-(* ::Subsubsection:: *)
+(* ::Subsubsection::Closed:: *)
 (*Testing functions*)
 
 
@@ -373,13 +375,27 @@ ValidXQ[x_]:=Module[{xFlag=True},
 ];
 
 
-ValidResIntQ[\[Beta]r_,\[Beta]th_]:=Module[{resFlag},
-	If[!(\[Beta]th>\[Beta]r>0), Message[KerrGeoFindResonance::invalidratio]; resFlag=False];
+ValidResIntQ[\[Beta]r_/;\[Beta]r!=0,\[Beta]\[Theta]_/;\[Beta]\[Theta]!=0,\[Beta]\[Phi]_/;\[Beta]\[Phi]!=0]:=Module[{resFlag},
+	If[(Abs[\[Beta]r]>Abs[\[Beta]\[Theta]]), Message[KerrGeoFindResonance::invalidRatio]; resFlag=False];
+	If[(Abs[\[Beta]r]>Abs[\[Beta]\[Phi]]), Message[KerrGeoFindResonance::invalidRatio]; resFlag=False];
+	If[(\[Beta]\[Theta] \[Beta]\[Phi]<0), Message[KerrGeoFindResonance::invalidRatio]; resFlag=False];
+	resFlag
+];
+ValidResIntQ[\[Beta]r_/;\[Beta]r!=0,\[Beta]\[Theta]_/;\[Beta]\[Theta]!=0,0]:=Module[{resFlag},
+	If[(Abs[\[Beta]r]>Abs[\[Beta]\[Theta]]), Message[KerrGeoFindResonance::invalidRatio]; resFlag=False];
+	resFlag
+];
+ValidResIntQ[\[Beta]r_/;\[Beta]r!=0,0,\[Beta]\[Phi]_/;\[Beta]\[Phi]!=0]:=Module[{resFlag},
+	If[(Abs[\[Beta]r]>Abs[\[Beta]\[Phi]]), Message[KerrGeoFindResonance::invalidRatio]; resFlag=False];
+	resFlag
+];
+ValidResIntQ[0,\[Beta]\[Theta]_/;\[Beta]\[Theta]!=0,\[Beta]\[Phi]_/;\[Beta]\[Phi]!=0]:=Module[{resFlag},
+	If[(\[Beta]\[Theta] \[Beta]\[Phi]<0), Message[KerrGeoFindResonance::invalidRatio]; resFlag=False];
 	resFlag
 ];
 
 
-(* ::Subsubsection:: *)
+(* ::Subsubsection::Closed:: *)
 (*Useful functions for root-finding*)
 
 
@@ -437,6 +453,13 @@ y1y2[0,p_,e_,x_/;x^2<1]:=y1y2[0,p,e,1];
 Rf[0,alpha_,beta_]:=beta^(-1/2)EllipticK[1-alpha/beta];
 
 
+(* ::Text:: *)
+(*r\[Theta] ratio*)
+
+
+r\[Theta]Ratio[a_, p_, e_, x_]:=Sqrt[y1y2[a,p,e,x]]Rf[0,1+del2y2[a,p,e,x],1-del2y2[a,p,e,x]]/Rf[0,1+del1y1[a,p,e,x],1-del1y1[a,p,e,x]];
+
+
 (* ::Subsubsection::Closed:: *)
 (*Given (a,e,x) and Subscript[\[CapitalOmega], r]/Subscript[\[CapitalOmega], \[Theta]]= Subscript[\[Beta], r]/Subscript[\[Beta], \[Theta]] find p*)
 
@@ -446,23 +469,22 @@ Rf[0,alpha_,beta_]:=beta^(-1/2)EllipticK[1-alpha/beta];
 (*	Root finding methods are based on those described in Sec.  VE*)
 
 
-Options[KerrGeoOrbitRThetaResonantP]={PrecisionGoal->Automatic, Rotation->"Both"};
+Options[KerrGeoOrbitRThetaResonantP]={PrecisionGoal->Automatic};
 
 
 KerrGeoOrbitRThetaResonantP[a_?NumericQ, e_?NumericQ, x_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Theta]_Integer}, opts:OptionsPattern[]]:=
-Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest},
+Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest,pSep},
 	(*See if the user specified some precision goal *)
-	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Theta]],Abort[]];
-	If[OptionValue[Rotation]=="Prograde" & x<0, Abort[]];
-	If[OptionValue[Rotation]=="Retrograde" & x>0, Abort[]];
-	
+	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Theta],0],Abort[]];
 	pg=OptionValue[PrecisionGoal];
 	ratio=\[Beta]r/\[Beta]\[Theta];
+	If[x>0&&ratio<0, Message[KerrGeoFindResonance::invalidPrograde]; Abort[]];
+	If[x<0&&ratio>0, Message[KerrGeoFindResonance::invalidRetrograde]; Abort[]];
 	(* pStar provides an initial guess for p. Note that p = pStar for e = 0 and a = 0*)
 	pStar=6/(1-ratio^2); (* See Eq 30 *)
 
 	(* Resonant condition defined by the equation below *)
-	resonantEqn[p_?NumericQ]:=Sqrt[y1y2[a,p,e,x]]Rf[0,1+del2y2[a,p,e,x],1-del2y2[a,p,e,x]]/Rf[0,1+del1y1[a,p,e,x],1-del1y1[a,p,e,x]]-ratio;
+	resonantEqn[p_?NumericQ]:=r\[Theta]Ratio[a, p, e, x]-Abs[ratio];
 	
 	(* Working precision of the root-finding method is based on the precision specified
 	 by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
@@ -484,18 +506,17 @@ Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest},
 (*Given (a,p,x) and Subscript[\[CapitalOmega], r]/Subscript[\[CapitalOmega], \[Theta]]= Subscript[\[Beta], r]/Subscript[\[Beta], \[Theta]] find e*)
 
 
-Options[KerrGeoOrbitRThetaResonantE]={PrecisionGoal->Automatic, Rotation->"Both"};
+Options[KerrGeoOrbitRThetaResonantE]={PrecisionGoal->Automatic};
 
 
 KerrGeoOrbitRThetaResonantE[a_?NumericQ, p_?NumericQ, x_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Theta]_Integer}, opts:OptionsPattern[]]:=
 Module[{pg,argpg,resonantEqn,e0Test,e1Test,eGuess,ee,ratio},
 	(*See if the user specified some precision goal *)
-	If[Not@ValidAQ[a]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Theta]],Abort[]];
-	If[OptionValue[Rotation]=="Prograde" & x<0, Abort[]];
-	If[OptionValue[Rotation]=="Retrograde" & x>0, Abort[]];
-	
+	If[Not@ValidAQ[a]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Theta],0],Abort[]];
 	pg=OptionValue[PrecisionGoal];
 	ratio=\[Beta]r/\[Beta]\[Theta];
+	If[x>0&&ratio<0, Message[KerrGeoFindResonance::invalidPrograde]; Abort[]];
+	If[x<0&&ratio>0, Message[KerrGeoFindResonance::invalidRetrograde]; Abort[]];
 	
 	(* Test to see if there is an eccentricity that will lead to a bound orbital resonance 
 	 based on the provided values of a, p, x *)
@@ -507,7 +528,7 @@ Module[{pg,argpg,resonantEqn,e0Test,e1Test,eGuess,ee,ratio},
 	eGuess=(p-e0Test)/(e1Test-e0Test);
 
 	(* Resonant condition defined by the equation below *)
-	resonantEqn[e_?NumericQ]:=Sqrt[y1y2[a,p,e,x]]Rf[0,1+del2y2[a,p,e,x],1-del2y2[a,p,e,x]]/Rf[0,1+del1y1[a,p,e,x],1-del1y1[a,p,e,x]]-ratio;
+	resonantEqn[e_?NumericQ]:=r\[Theta]Ratio[a, p, e, x]-Abs[ratio];
 	
 	(* Working precision of the root-finding method is based on the precision specified
 	 by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
@@ -529,30 +550,29 @@ Module[{pg,argpg,resonantEqn,e0Test,e1Test,eGuess,ee,ratio},
 (*Given (a,p,e) and Subscript[\[CapitalOmega], r]/Subscript[\[CapitalOmega], \[Theta]]= Subscript[\[Beta], r]/Subscript[\[Beta], \[Theta]] find x*)
 
 
-Options[KerrGeoOrbitRThetaResonantX]={PrecisionGoal->Automatic, Rotation->"Both"};
+Options[KerrGeoOrbitRThetaResonantX]={PrecisionGoal->Automatic};
 
 
 KerrGeoOrbitRThetaResonantX[a_?NumericQ, p_?NumericQ, e_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Theta]_Integer}, opts:OptionsPattern[]]:=
-Module[{pg,rtt,argpg,resonantEqn,x1Test1,x1Test2,xGuess,xx,xxx,ratio},
+Module[{pg,argpg,resonantEqn,x0Test,x1Test,xGuess,xx,xxx,ratio},
 	(*See if the user specified some precision goal *)
-	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Theta]],Abort[]];
-	
-	rtt=OptionValue[Rotation];
+	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Theta],0],Abort[]];
+
 	pg=OptionValue[PrecisionGoal];
 	ratio=\[Beta]r/\[Beta]\[Theta];
-	
 	(* Test to see if there is an inclination angle that will lead to a bound orbital resonance 
 	 based on the provided values of a, p, e *)
-	x1Test1=KerrGeoOrbitRThetaResonantP[a,e,1,{\[Beta]r,\[Beta]\[Theta]},PrecisionGoal->pg];
-	x1Test2=KerrGeoOrbitRThetaResonantP[a,e,-1,{\[Beta]r,\[Beta]\[Theta]},PrecisionGoal->pg];
+	x0Test=KerrGeoOrbitRThetaResonantP[a,e,0,{\[Beta]r,\[Beta]\[Theta]},opts];
+	x1Test=KerrGeoOrbitRThetaResonantP[a,e,Sign[ratio],{\[Beta]r,\[Beta]\[Theta]},opts];
 	
-	If[p>x1Test2 || p< x1Test1, Message[KerrGeoFindResonance::noresonance, x1Test1, x1Test2]; Abort[];];
-	If[p==x1Test1,Return[1]];
-	If[p==x1Test2,Return[-1]];
-	xGuess=-(2p-(x1Test2+x1Test1))/(x1Test2-x1Test1);
+	If[ratio>0 && (p<x1Test||x0Test<p), Message[KerrGeoFindResonance::noresonance, x1Test, x0Test]; Abort[];];
+	If[ratio<0 && (p<x0Test||x1Test<p), Message[KerrGeoFindResonance::noresonance, x0Test, x1Test]; Abort[];];
+	If[p==x0Test,Return[0]];
+	If[p==x1Test,Return[Sign[ratio]]];
+	xGuess=Sign[ratio](p-x0Test)/(x1Test-x0Test);
 
 	(* Resonant condition defined by the equation below *)
-	resonantEqn[x_?NumericQ]:=Sqrt[y1y2[a,p,e,x]]Rf[0,1+del2y2[a,p,e,x],1-del2y2[a,p,e,x]]/Rf[0,1+del1y1[a,p,e,x],1-del1y1[a,p,e,x]]-ratio;
+	resonantEqn[x_?NumericQ]:=r\[Theta]Ratio[a, p, e, x]-Abs[ratio];
 	
 	(* Working precision of the root-finding method is based on the precision specified
 	 by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
@@ -566,10 +586,7 @@ Module[{pg,rtt,argpg,resonantEqn,x1Test1,x1Test2,xGuess,xx,xxx,ratio},
 		xxx=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess}]],
 		xxx=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess},PrecisionGoal->pg,WorkingPrecision->0.95argpg]],
 		xxx=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess},PrecisionGoal->pg,WorkingPrecision->0.95argpg]]
-	];
-	If[(rtt=="Prograde"&&xxx>0)||(rtt=="Retrograde"&&xxx<0)||rtt=="Both", Return[xxx]];
-	If[rtt=="Prograde"&&xxx<0, Message[KerrGeoFindResonance::retrograde, xxx]; Abort[]];
-	If[rtt=="Retrograde"&&xxx>0, Message[KerrGeoFindResonance::prograde, xxx]; Abort[]];
+	]
 ];
 
 
@@ -585,13 +602,14 @@ Module[{pg,rtt,argpg,resonantEqn,x1Test1,x1Test2,xGuess,xx,xxx,ratio},
 (*Same as those of r\[Theta]-resonance*)
 
 
-(* ::Subsubsection::Closed:: *)
+(* ::Subsubsection:: *)
 (*Useful functions for root-finding*)
 
 
-r\[Phi]Ratio[a_, p_, e_, x_/;x!=0] := Abs[KerrGeoFrequencies[a, p, e, x, Time->"Mino"]["\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(r\)]\)"]/KerrGeoFrequencies[a, p, e, x, Time->"Mino"]["\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Phi]\)]\)"]]
+r\[Phi]Ratio[a_, p_, e_, x_/;x!=0]:= Sign[x] ("\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(r\)]\)")/("\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Phi]\)]\)")/.KerrGeoFrequencies[a, p, e, x, Time->"Mino"]
 
-r\[Phi]Ratio[a_, p_, e_/;e!=1, x_/;x==0]:=
+
+r\[Phi]Ratio[a_, p_, e_/;e<1, x_/;x==0]:=
 Module[{S, P, r1, r2, r3, r4, EnSquared, Q, kr, k\[Theta], factor1, factor2, rPlus, rMinus, hPlus, hMinus, hr, BrPlus, BrMinus, Br, r\[Theta]Ratio},
 	(* S=r3+r4, P=r3*r4 *)
 	P = (a^2(a^4(-1+e^2)2+p^4+2a^2p(-2+p+e^2(2+p))))/(a^4(-1+e^2)^2+2a^2(1+e^2)p^2+(-4+p)p^3);
@@ -602,8 +620,8 @@ Module[{S, P, r1, r2, r3, r4, EnSquared, Q, kr, k\[Theta], factor1, factor2, rPl
     r2 = p/(1+e);
     r3 = (S+Sqrt[S^2-4P])/2;
     r4 = (S-Sqrt[S^2-4P])/2;
-    kr = (r1-r2)/(r1-r3)(r3-r4)/(r2-r4);
-    k\[Theta] = (1-EnSquared)a^2/Q;
+    kr = Abs[(r1-r2)/(r1-r3)(r3-r4)/(r2-r4)];
+    k\[Theta] = Abs[(1-EnSquared)a^2/Q];
     factor1 = Sqrt[(r1-r3)(r2-r4)2(1-e^2)a^2/(2p^2P)];
     r\[Theta]Ratio = factor1 EllipticK[k\[Theta]]/EllipticK[kr];
     
@@ -617,8 +635,9 @@ Module[{S, P, r1, r2, r3, r4, EnSquared, Q, kr, k\[Theta], factor1, factor2, rPl
     BrMinus = rMinus/(r3-rMinus)(EllipticK[kr]-(r2-r3)/(r2-rMinus)EllipticPi[hPlus, kr]);
     Br = factor2(BrPlus-BrMinus);
     (* {prograde, retrograde} *)
-    {Abs[1/(1/r\[Theta]Ratio+Br)],Abs[1/(-1/r\[Theta]Ratio+Br)]}
-]
+    {1/(1/r\[Theta]Ratio+Br),-1/(-1/r\[Theta]Ratio+Br)}
+];
+
 
 r\[Phi]Ratio[a_, p_, e_/;e==1, x_/;x==0]:=
 Module[{S, P, r1, r2, r3, r4, EnSquared, Q, kr, k\[Theta], factor1, factor2, rPlus, rMinus, hPlus, hMinus, hr, BrPlus, BrMinus, Br, r\[Theta]Ratio},
@@ -645,33 +664,37 @@ Module[{S, P, r1, r2, r3, r4, EnSquared, Q, kr, k\[Theta], factor1, factor2, rPl
     BrMinus = rMinus/(r3-rMinus)(EllipticK[kr]-(r2-r3)/(r2-rMinus)EllipticPi[hPlus, kr]);
     Br = factor2(BrPlus-BrMinus);
     (* {prograde, retrograde} *)
-    {Abs[1/(1/r\[Theta]Ratio+Br)],Abs[1/(-1/r\[Theta]Ratio+Br)]}
-]
+    {1/(1/r\[Theta]Ratio+Br),-1/(-1/r\[Theta]Ratio+Br)}
+];
 
 
 (* ::Subsubsection::Closed:: *)
 (*Given (a,e,x) and Subscript[\[CapitalOmega], r]/Subscript[\[CapitalOmega], \[Phi]]= Subscript[\[Beta], r]/Subscript[\[Beta], \[Phi]] find p*)
 
 
-Options[KerrGeoOrbitRPhiResonantP]={PrecisionGoal->Automatic, Rotation->"Both"};
+Options[KerrGeoOrbitRPhiResonantP]={PrecisionGoal->Automatic};
 
 
-KerrGeoOrbitRPhiResonantP[a_?NumericQ, e_?NumericQ, x_?NumericQ/;x!=0, {\[Beta]r_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
-Module[{pg,rtt,ratio,argpg,resonantEqn,pStar,pp,pgTest},
+KerrGeoOrbitRPhiResonantP[a_?NumericQ, e_?NumericQ, x_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
+Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest},
 	(*See if the user specified some precision goal *)
-	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Phi]],Abort[]];
-	
-	rtt=OptionValue[Rotation];
-	If[rtt=="Prograde" & x<0, Abort[]];
-	If[rtt=="Retrograde" & x>0, Abort[]];
+	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,0,\[Beta]\[Phi]],Abort[]];
 	
 	pg=OptionValue[PrecisionGoal];
 	ratio=\[Beta]r/\[Beta]\[Phi];
+	If[x>0&&ratio<0, Message[KerrGeoFindResonance::invalidPrograde]; Abort[]];
+	If[x<0&&ratio>0, Message[KerrGeoFindResonance::invalidRetrograde]; Abort[]];
 	(* pStar provides an initial guess for p. Note that p = pStar for e = 0 and a = 0*)
 	pStar=6/(1-ratio^2);
-
+	
 	(* Resonant condition defined by the equation below *)
-	resonantEqn[p_?NumericQ]:=r\[Phi]Ratio[a, p, e, x]-ratio;
+	If[x==0,
+		If[ratio>0,
+			resonantEqn[p_?NumericQ]:= r\[Phi]Ratio[a, p, e, x][[1]]-Abs[ratio],
+			resonantEqn[p_?NumericQ]:= r\[Phi]Ratio[a, p, e, x][[2]]-Abs[ratio]
+		],
+		resonantEqn[p_?NumericQ]:= r\[Phi]Ratio[a, p, e, x]-Abs[ratio]
+	];
 	
 	(* Working precision of the root-finding method is based on the precision specified
 	 by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
@@ -682,55 +705,10 @@ Module[{pg,rtt,ratio,argpg,resonantEqn,pStar,pp,pgTest},
 	If[pg==Infinity,pg=$MachinePrecision];
 	
 	If[pg==$MachinePrecision,
-		Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar}]],
+		Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar},StepMonitor:>Print[pp]]],
 		Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar},PrecisionGoal->pg,WorkingPrecision->pg]],
 		Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar},PrecisionGoal->pg,WorkingPrecision->pg]]
 	]
-];
-
-KerrGeoOrbitRPhiResonantP[a_?NumericQ, e_?NumericQ, x_?NumericQ/;x==0, {\[Beta]r_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
-Module[{pg,rtt,ratio,argpg,resonantEqn,pStar,pp,pp1,pp2,pgTest},
-	(*See if the user specified some precision goal *)
-	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Phi]],Abort[]];
-	
-	rtt=OptionValue[Rotation];
-	pg=OptionValue[PrecisionGoal];
-	ratio=\[Beta]r/\[Beta]\[Phi];
-	(* pStar provides an initial guess for p. Note that p = pStar for e = 0 and a = 0*)
-	pStar=6/(1-ratio^2);
-	If[rtt=="Prograde"||rtt=="Both",
-		(* Resonant condition defined by the equation below *)
-		resonantEqn[p_?NumericQ]:=r\[Phi]Ratio[a, p, e, 0][[1]]-ratio;
-		(* Working precision of the root-finding method is based on the precision specified
-			by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
-			is the default precision if not other precision specifications are made. *)
-		argpg=Precision[{resonantEqn[pStar],a,e,x,ratio}];
-		If[argpg==$MachinePrecision,pg=argpg];
-		If[(Not@NumericQ[pg]||pg>argpg),pg=argpg];
-		If[pg==Infinity,pg=$MachinePrecision];
-		If[pg==$MachinePrecision,
-				pp1=Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar}]],
-				pp1=Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar},PrecisionGoal->pg,WorkingPrecision->pg]],
-				pp1=Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar},PrecisionGoal->pg,WorkingPrecision->pg]]
-		];
-	];
-	If[rtt=="Retrograde"||rtt=="Both",
-		(* Resonant condition defined by the equation below *)
-		resonantEqn[p_?NumericQ]:=r\[Phi]Ratio[a, p, e, 0][[2]]-ratio;
-		(* Working precision of the root-finding method is based on the precision specified
-		by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
-		is the default precision if not other precision specifications are made. *)
-		argpg=Precision[{resonantEqn[pStar],a,e,x,ratio}];
-		If[argpg==$MachinePrecision,pg=argpg];
-		If[(Not@NumericQ[pg]||pg>argpg),pg=argpg];
-		If[pg==Infinity,pg=$MachinePrecision];
-		If[pg==$MachinePrecision,
-				pp2=Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar}]],
-				pp2=Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar},PrecisionGoal->pg,WorkingPrecision->pg]],
-				pp2=Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar},PrecisionGoal->pg,WorkingPrecision->pg]]
-		];
-	];
-	Switch[rtt,"Prograde", Return[pp1],"Retrograde", Return[pp2],"Both", Return[{pp1, pp2}]];
 ];
 
 
@@ -738,20 +716,18 @@ Module[{pg,rtt,ratio,argpg,resonantEqn,pStar,pp,pp1,pp2,pgTest},
 (*Given (a,p,x) and Subscript[\[CapitalOmega], r]/Subscript[\[CapitalOmega], \[Phi]]= Subscript[\[Beta], r]/Subscript[\[Beta], \[Phi]] find e*)
 
 
-Options[KerrGeoOrbitRPhiResonantE]={PrecisionGoal->Automatic, Rotation->"Both"};
+Options[KerrGeoOrbitRPhiResonantE]={PrecisionGoal->Automatic};
 
 
-KerrGeoOrbitRPhiResonantE[a_?NumericQ, p_?NumericQ, x_?NumericQ/;x!=0, {\[Beta]r_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
-Module[{pg,rtt,argpg,resonantEqn,e0Test,e1Test,eGuess,ee,ratio},
+KerrGeoOrbitRPhiResonantE[a_?NumericQ, p_?NumericQ, x_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
+Module[{pg,argpg,resonantEqn,e0Test,e1Test,eGuess,ee,ratio},
 	(*See if the user specified some precision goal *)
-	If[Not@ValidAQ[a]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Phi]],Abort[]];
+	If[Not@ValidAQ[a]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,0,\[Beta]\[Phi]],Abort[]];
 	
 	pg=OptionValue[PrecisionGoal];
-	rtt=OptionValue[Rotation];
-	If[rtt=="Prograde" & x<0, Abort[]];
-	If[rtt=="Retrograde" & x>0, Abort[]];
-	
 	ratio=\[Beta]r/\[Beta]\[Phi];
+	If[x>0&&ratio<0, Message[KerrGeoFindResonance::invalidPrograde]; Abort[]];
+	If[x<0&&ratio>0, Message[KerrGeoFindResonance::invalidRetrograde]; Abort[]];
 	
 	(* Test to see if there is an eccentricity that will lead to a bound orbital resonance 
 	 based on the provided values of a, p, x *)
@@ -763,7 +739,13 @@ Module[{pg,rtt,argpg,resonantEqn,e0Test,e1Test,eGuess,ee,ratio},
 	eGuess=(p-e0Test)/(e1Test-e0Test);
 
 	(* Resonant condition defined by the equation below *)
-	resonantEqn[e_?NumericQ]:= r\[Phi]Ratio[a, p, e, x]-ratio;
+	If[x==0,
+		If[ratio>0,
+			resonantEqn[e_?NumericQ]:= r\[Phi]Ratio[a, p, e, x][[1]]-Abs[ratio],
+			resonantEqn[e_?NumericQ]:= r\[Phi]Ratio[a, p, e, x][[2]]-Abs[ratio]
+		],
+		resonantEqn[e_?NumericQ]:= r\[Phi]Ratio[a, p, e, x]-Abs[ratio]
+	];
 	
 	(* Working precision of the root-finding method is based on the precision specified
 	 by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
@@ -780,183 +762,411 @@ Module[{pg,rtt,argpg,resonantEqn,e0Test,e1Test,eGuess,ee,ratio},
 	]
 ];
 
-KerrGeoOrbitRPhiResonantE[a_?NumericQ, p_?NumericQ, x_?NumericQ/;x==0, {\[Beta]r_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
-Module[{pg,rtt,argpg,resonantEqn,e0Test,e1Test,eGuess,ee,ee1,ee2,ratio},
-	(*See if the user specified some precision goal *)
-	If[Not@ValidAQ[a]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Phi]],Abort[]];
-	
-	pg=OptionValue[PrecisionGoal];
-	rtt=OptionValue[Rotation];
-	
-	ratio=\[Beta]r/\[Beta]\[Phi];
-	e0Test=KerrGeoOrbitRPhiResonantP[a,0,x,{\[Beta]r,\[Beta]\[Phi]},opts];
-	e1Test=KerrGeoOrbitRPhiResonantP[a,1,x,{\[Beta]r,\[Beta]\[Phi]},opts];
-	
-	If[rtt=="Prograde",
-		If[p<e0Test||e1Test<p, Message[KerrGeoFindResonance::noresonance, e0Test, e1Test]; Abort[];];
-		If[p==e0Test,Return[0]];
-		If[p==e1Test,Return[1]];
-		eGuess=(p-e0Test)/(e1Test-e0Test);
-	
-		(* Resonant condition defined by the equation below *)
-		resonantEqn[e_?NumericQ]:= r\[Phi]Ratio[a, p, e, x][[1]]-ratio;
-		
-		(* Working precision of the root-finding method is based on the precision specified
-		 by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
-		 is the default precision if not other precision specifications are made. *)
-		argpg=Precision[{resonantEqn[eGuess],a,p,x,ratio}];
-		If[argpg==$MachinePrecision,pg=argpg];
-		If[(Not@NumericQ[pg]||pg>argpg),pg=argpg];
-		If[pg==Infinity,pg=$MachinePrecision];
-		If[pg==$MachinePrecision,
-			ee1=Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess}]],
-			ee1=Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess},PrecisionGoal->pg,WorkingPrecision->pg]],
-			ee1=Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess},PrecisionGoal->pg,WorkingPrecision->pg]]
-		];
-		Return[ee1];
-	];
-	
-	If[rtt=="Retrograde",
-		If[p<e0Test||e1Test<p, Message[KerrGeoFindResonance::noresonance, e0Test, e1Test]; Abort[];];
-		If[p==e0Test,Return[0]];
-		If[p==e1Test,Return[1]];
-		eGuess=(p-e0Test)/(e1Test-e0Test);
-	
-		(* Resonant condition defined by the equation below *)
-		resonantEqn[e_?NumericQ]:= r\[Phi]Ratio[a, p, e, x][[2]]-ratio;
-		
-		(* Working precision of the root-finding method is based on the precision specified
-		 by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
-		 is the default precision if not other precision specifications are made. *)
-		argpg=Precision[{resonantEqn[eGuess],a,p,x,ratio}];
-		If[argpg==$MachinePrecision,pg=argpg];
-		If[(Not@NumericQ[pg]||pg>argpg),pg=argpg];
-		If[pg==Infinity,pg=$MachinePrecision];
-		If[pg==$MachinePrecision,
-			ee2=Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess}]],
-			ee2=Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess},PrecisionGoal->pg,WorkingPrecision->pg]],
-			ee2=Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess},PrecisionGoal->pg,WorkingPrecision->pg]]
-		];
-		Return[ee2];
-	];
-	
-	If[rtt=="Both",
-		If[p<e0Test[[2]]||e1Test[[2]]<p<e0Test[[1]]|| e1Test[[1]]<p,
-			Message[KerrGeoFindResonance::noresonance, e0Test[[1]], e1Test[[1]]];
-			Message[KerrGeoFindResonance::noresonance, e0Test[[2]], e1Test[[2]]];
-			Abort[]
-		];
-		If[e0Test[[1]]<p<e1Test[[1]],
-			eGuess=(p-e0Test[[1]])/(e1Test[[1]]-e0Test[[1]]);
-			resonantEqn[e_?NumericQ]:= r\[Phi]Ratio[a, p, e, x][[1]]-ratio;
-			argpg=Precision[{resonantEqn[eGuess],a,p,x,ratio}];
-			If[argpg==$MachinePrecision,pg=argpg];
-			If[(Not@NumericQ[pg]||pg>argpg),pg=argpg];
-			If[pg==Infinity,pg=$MachinePrecision];
-			If[pg==$MachinePrecision,
-				ee1=Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess}]],
-				ee1=Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess},PrecisionGoal->pg,WorkingPrecision->pg]],
-				ee1=Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess},PrecisionGoal->pg,WorkingPrecision->pg]]
-			];
-			Return[ee1];
-		];
-		If[e0Test[[2]]<p<e1Test[[2]],
-			eGuess=(p-e0Test[[2]])/(e1Test[[2]]-e0Test[[2]]);
-			resonantEqn[e_?NumericQ]:= r\[Phi]Ratio[a, p, e, x][[2]]-ratio;
-			argpg=Precision[{resonantEqn[eGuess],a,p,x,ratio}];
-			If[argpg==$MachinePrecision,pg=argpg];
-			If[(Not@NumericQ[pg]||pg>argpg),pg=argpg];
-			If[pg==Infinity,pg=$MachinePrecision];
-			If[pg==$MachinePrecision,
-				ee2=Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess}]],
-				ee2=Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess},PrecisionGoal->pg,WorkingPrecision->pg]],
-				ee2=Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess},PrecisionGoal->pg,WorkingPrecision->pg]]
-			];
-			Return[ee2];	
-		];
-	];
-];
 
-
-(* ::Subsubsection:: *)
+(* ::Subsubsection::Closed:: *)
 (*Given (a,p,e) and Subscript[\[CapitalOmega], r]/Subscript[\[CapitalOmega], \[Phi]]= Subscript[\[Beta], r]/Subscript[\[Beta], \[Phi]] find x*)
 
 
-Options[KerrGeoOrbitRPhiResonantX]={PrecisionGoal->Automatic, Rotation->"Both"};
+Options[KerrGeoOrbitRPhiResonantX]={PrecisionGoal->Automatic};
 
 
 KerrGeoOrbitRPhiResonantX[a_?NumericQ, p_?NumericQ, e_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
-Module[{pg,rtt,argpg,resonantEqn,x0Test1,x0Test2,x1Test1,x1Test2,xGuess,xx1,xx2,xx,ratio},
+Module[{pg,rtt,argpg,resonantEqn,x0Test, x1Test, x0Test1,x0Test2,x1Test1,x1Test2,xGuess,xx1,xx2,xx,ratio},
 	(*See if the user specified some precision goal *)
-	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Phi]],Abort[]];
-	
-	rtt=OptionValue[Rotation];
+	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidResIntQ[\[Beta]r,0,\[Beta]\[Phi]],Abort[]];
 	pg=OptionValue[PrecisionGoal];
 	ratio=\[Beta]r/\[Beta]\[Phi];
 	
 	(* Test to see if there is an eccentricity that will lead to a bound orbital resonance 
-	 based on the provided values of a, p, x *)
-	{x0Test1,x0Test2}=KerrGeoOrbitRPhiResonantP[a,e,0,{\[Beta]r,\[Beta]\[Phi]}, PrecisionGoal->pg];
-	x1Test1=KerrGeoOrbitRPhiResonantP[a,e,1,{\[Beta]r,\[Beta]\[Phi]}, PrecisionGoal->pg];
-	x1Test2=KerrGeoOrbitRPhiResonantP[a,e,-1,{\[Beta]r,\[Beta]\[Phi]}, PrecisionGoal->pg];
-	If[p<x1Test1||x1Test2<p, Message[KerrGeoFindResonance::noresonance, x1Test1, x1Test2]; Abort[];];
-	If[x1Test1<p<x0Test2&&rtt=="Retrograde", Message[KerrGeoFindResonance::noresonance, x0Test2, x1Test2]; Abort[];];
-	If[x0Test1<p<x1Test2&&rtt=="Prograde", Message[KerrGeoFindResonance::noresonance, x1Test1, x0Test1]; Abort[];];
-	If[p==x1Test1,Return[1]];
-	If[p==x1Test2,Return[-1]];
-	If[p==x0Test1||p==x0Test2,Return[0]];
-	(* Resonant condition defined by the equation below *)
-	resonantEqn[x_?NumericQ]:=r\[Phi]Ratio[a, p, e, x]-ratio;
+	based on the provided values of a, p, x *)
+	(*See if the user specified some precision goal *)
+	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Theta]],Abort[]];
+
+	pg=OptionValue[PrecisionGoal];
+	ratio=\[Beta]r/\[Beta]\[Phi];
+	(* Test to see if there is an inclination angle that will lead to a bound orbital resonance 
+	 based on the provided values of a, p, e *)
+	x0Test=KerrGeoOrbitRPhiResonantP[a,e,0,{\[Beta]r,\[Beta]\[Phi]},opts];
+	x1Test=KerrGeoOrbitRPhiResonantP[a,e,Sign[ratio],{\[Beta]r,\[Beta]\[Phi]},opts];
 	
-	If[x1Test1<p<x0Test1&&(rtt=="Prograde"||rtt=="Both"),
-		xGuess = (p-x0Test1)/(x1Test1-x0Test1);
-		(* Working precision of the root-finding method is based on the precision specified
-		 by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
-		 is the default precision if not other precision specifications are made. *)
-		argpg=Precision[{resonantEqn[xGuess],a,p,e,ratio}];
-		If[argpg==$MachinePrecision,pg=0.9argpg];
-		If[(Not@NumericQ[pg]||pg>argpg),pg=0.9argpg];
-		If[pg==Infinity,pg=$MachinePrecision];
-		If[pg==$MachinePrecision,
-			xx1=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess}]],
-			xx1=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess},PrecisionGoal->pg,WorkingPrecision->0.95argpg]],
-			xx1=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess},PrecisionGoal->pg,WorkingPrecision->0.95argpg]]
-		]
-	];
-	If[x0Test2<p<x1Test2&&(rtt=="Retrograde"||rtt=="Both"),
-		xGuess = -(p-x0Test2)/(x1Test2-x0Test2);
-		(* Working precision of the root-finding method is based on the precision specified
-		 by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
-		 is the default precision if not other precision specifications are made. *)
-		argpg=Precision[{resonantEqn[xGuess],a,p,e,ratio}];
-		If[argpg==$MachinePrecision,pg=0.9argpg];
-		If[(Not@NumericQ[pg]||pg>argpg),pg=0.9argpg];
-		If[pg==Infinity,pg=$MachinePrecision];
-		If[pg==$MachinePrecision,
-			xx2=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess}]],
-			xx2=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess},PrecisionGoal->pg,WorkingPrecision->0.95argpg]],
-			xx2=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess},PrecisionGoal->pg,WorkingPrecision->0.95argpg]]
-		]
-	];
-	Switch[rtt,
-		"Prograde", Return[xx1],
-		"Retrograde", Return[xx2],
-		"Both", 
-			If[x1Test1<p<x0Test2, Return[xx1]];
-			If[x0Test2<p<x0Test1, Return[{xx1, xx2}]];
-			If[x0Test1<p<x1Test2, Return[xx2]];
-	];
+	If[ratio>0 && (p<x1Test||x0Test<p), Message[KerrGeoFindResonance::noresonance, x1Test, x0Test]; Abort[];];
+	If[ratio<0 && (p<x0Test||x1Test<p), Message[KerrGeoFindResonance::noresonance, x0Test, x1Test]; Abort[];];
+	If[p==x0Test,Return[0]];
+	If[p==x1Test,Return[Sign[ratio]]];
+	xGuess=Sign[ratio](p-x0Test)/(x1Test-x0Test);
+
+	(* Resonant condition defined by the equation below *)
+	resonantEqn[x_?NumericQ]:=r\[Phi]Ratio[a, p, e, x]-Abs[ratio];
+	
+	(* Working precision of the root-finding method is based on the precision specified
+	 by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
+	 is the default precision if not other precision specifications are made. *)
+	argpg=Precision[{a,p,e,ratio}];
+	If[argpg==$MachinePrecision,pg=0.9argpg];
+	If[(Not@NumericQ[pg]||pg>argpg),pg=0.9argpg];
+	If[pg==Infinity,pg=$MachinePrecision];
+
+	If[pg==$MachinePrecision,
+		xxx=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess}]],
+		xxx=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess},PrecisionGoal->pg,WorkingPrecision->0.95argpg]],
+		xxx=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess},PrecisionGoal->pg,WorkingPrecision->0.95argpg]]
+	]
 ];
 
 
 (* ::Subsection:: *)
+(*\[Phi]\[Theta]-resonance*)
+
+
+(* ::Subsubsection:: *)
+(*Testing functions*)
+
+
+(* ::Text:: *)
+(*Same as those of r\[Theta]-resonance*)
+
+
+(* ::Subsubsection:: *)
+(*Useful functions for root-finding*)
+
+
+\[Phi]\[Theta]Ratio[a_, p_, e_, x_/;x!=0]:=Sign[x] ("\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Phi]\)]\)")/("\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Theta]\)]\)")/.KerrGeoFrequencies[a, p, e, x, Time->"Mino"]
+
+
+\[Phi]\[Theta]Ratio[a_, p_, e_/;e!=1, x_/;x==0]:=
+Module[{S, P, r1, r2, r3, r4, EnSquared, Q, kr, k\[Theta], factor1, factor2, rPlus, rMinus, hPlus, hMinus, hr, BrPlus, BrMinus, Br, r\[Theta]Ratio},
+	(* S=r3+r4, P=r3*r4 *)
+	P = (a^2(a^4(-1+e^2)2+p^4+2a^2p(-2+p+e^2(2+p))))/(a^4(-1+e^2)^2+2a^2(1+e^2)p^2+(-4+p)p^3);
+	S = (2(a^2(-1+e^2)+p^2)^2)/(a^4(-1+e^2)^2+2a^2(1+e^2)p^2+(-4+p)p^3);
+	EnSquared = 1+2(-1+e^2)/(2p+S-e^2S);
+    Q = 2p^2P/(a^2(2p+S-e^2S));
+    r1 = p/(1-e);
+    r2 = p/(1+e);
+    r3 = (S+Sqrt[S^2-4P])/2;
+    r4 = (S-Sqrt[S^2-4P])/2;
+    kr = (r1-r2)/(r1-r3)(r3-r4)/(r2-r4);
+    k\[Theta] = (1-EnSquared)a^2/Q;
+    factor1 = Sqrt[(r1-r3)(r2-r4)2(1-e^2)a^2/(2p^2P)];
+    r\[Theta]Ratio = factor1 EllipticK[k\[Theta]]/EllipticK[kr];
+    
+    rPlus = 1+Sqrt[1-a^2];
+    rMinus = 1-Sqrt[1-a^2];
+    hr = (r1-r2)/(r1-r3);
+    hPlus = hr (r3-rPlus)/(r2-rPlus);
+    hMinus = hr (r3-rMinus)/(r2-rMinus);
+    factor2 = 2a/(Pi(rPlus-rMinus)Sqrt[(1-EnSquared)(r1-r3)(r2-r4)])2Sqrt[EnSquared];
+    BrPlus = rPlus/(r3-rPlus)(EllipticK[kr]-(r2-r3)/(r2-rPlus)EllipticPi[hPlus, kr]);
+    BrMinus = rMinus/(r3-rMinus)(EllipticK[kr]-(r2-r3)/(r2-rMinus)EllipticPi[hPlus, kr]);
+    Br = factor2(BrPlus-BrMinus);
+    (* {prograde, retrograde} *)
+    {1+Br r\[Theta]Ratio, 1-Br r\[Theta]Ratio}
+];
+
+
+\[Phi]\[Theta]Ratio[a_, p_, e_/;e==1, x_/;x==0]:=
+Module[{S, P, r1, r2, r3, r4, EnSquared, Q, kr, k\[Theta], factor1, factor2, rPlus, rMinus, hPlus, hMinus, hr, BrPlus, BrMinus, Br, r\[Theta]Ratio},
+	(* S=r3+r4, P=r3*r4 *)
+	P = (a^2 (4 a^2 p^2+p^4))/(4 a^2 p^2+(-4+p) p^3);
+	S = (2 p^4)/(4 a^2 p^2 + (-4 + p) p^3);
+	EnSquared = 1;
+    Q = 2p^2P/(a^2 2p);
+    (* r1=p/(1-e) diverges *)
+    r2 = p/2;
+    r3 = (S+Sqrt[S^2-4P])/2;
+    r4 = (S-Sqrt[S^2-4P])/2;
+    kr = (r3-r4)/(r2-r4);
+    k\[Theta] = (1-EnSquared)a^2/Q;
+    factor1 = Sqrt[(2p)(r2-r4)2a^2/(2p^2P)];
+    r\[Theta]Ratio = factor1 EllipticK[k\[Theta]]/EllipticK[kr];
+    
+    rPlus = 1+Sqrt[1-a^2];
+    rMinus = 1-Sqrt[1-a^2];
+    hPlus = (r3-rPlus)/(r2-rPlus);
+    hMinus = (r3-rMinus)/(r2-rMinus);
+    factor2 = 2a/(Pi(rPlus-rMinus)Sqrt[2(r2-r4)])2Sqrt[EnSquared];
+    BrPlus = rPlus/(r3-rPlus)(EllipticK[kr]-(r2-r3)/(r2-rPlus)EllipticPi[hPlus, kr]);
+    BrMinus = rMinus/(r3-rMinus)(EllipticK[kr]-(r2-r3)/(r2-rMinus)EllipticPi[hPlus, kr]);
+    Br = factor2(BrPlus-BrMinus);
+    (* {prograde, retrograde} *)
+    {1+Br r\[Theta]Ratio, 1-Br r\[Theta]Ratio}
+];
+
+
+(* ::Subsubsection::Closed:: *)
+(*Given (a,e,x) and Subscript[\[CapitalOmega], \[Phi]]/Subscript[\[CapitalOmega], \[Theta]]= Subscript[\[Beta], \[Phi]]/Subscript[\[Beta], \[Theta]] find p*)
+
+
+Options[KerrGeoOrbitPhiThetaResonantP]={PrecisionGoal->Automatic};
+
+
+KerrGeoOrbitPhiThetaResonantP[a_?NumericQ, e_?NumericQ, x_?NumericQ, {\[Beta]\[Theta]_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
+Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest},
+	(*See if the user specified some precision goal *)
+	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidXQ[x]||Not@ValidResIntQ[0,\[Beta]\[Theta],\[Beta]\[Phi]],Abort[]];
+	
+	pg=OptionValue[PrecisionGoal];
+	ratio=\[Beta]\[Phi]/\[Beta]\[Theta];
+	If[x>0&&ratio<1, Message[KerrGeoFindResonance::invalidPrograde]; Abort[]];
+	If[x<0&&ratio>1, Message[KerrGeoFindResonance::invalidRetrograde]; Abort[]];
+	(* pStar provides an initial guess for p. Note that p = pStar for e = 0*)
+	pStar=(2 a/Abs[ratio-1])^(2/3);
+
+	(* Resonant condition defined by the equation below *)
+	If[x==0,
+		If[ratio>1,
+			resonantEqn[p_?NumericQ]:= \[Phi]\[Theta]Ratio[a, p, e, x][[1]]-Abs[ratio],
+			resonantEqn[p_?NumericQ]:= \[Phi]\[Theta]Ratio[a, p, e, x][[2]]-Abs[ratio]
+		],
+		resonantEqn[p_?NumericQ]:= \[Phi]\[Theta]Ratio[a, p, e, x]-Abs[ratio]
+	];
+	
+	(* Working precision of the root-finding method is based on the precision specified
+	 by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
+	 is the default precision if not other precision specifications are made. *)
+	argpg=Precision[{resonantEqn[pStar],a,e,x,ratio}];
+	If[argpg==$MachinePrecision,pg=argpg];
+	If[(Not@NumericQ[pg]||pg>argpg),pg=argpg];
+	If[pg==Infinity,pg=$MachinePrecision];
+	
+	If[pg==$MachinePrecision,
+		Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar}]],
+		Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar},PrecisionGoal->pg,WorkingPrecision->pg]],
+		Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar},PrecisionGoal->pg,WorkingPrecision->pg]]
+	]
+];
+
+
+(* ::Subsubsection::Closed:: *)
+(*Given (a,p,x) and Subscript[\[CapitalOmega], \[Phi]]/Subscript[\[CapitalOmega], \[Theta]]= Subscript[\[Beta], \[Phi]]/Subscript[\[Beta], \[Theta]] find e*)
+
+
+Options[KerrGeoOrbitPhiThetaResonantE]={PrecisionGoal->Automatic};
+
+
+KerrGeoOrbitPhiThetaResonantE[a_?NumericQ, p_?NumericQ, x_?NumericQ, {\[Beta]\[Theta]_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
+Module[{pg,argpg,resonantEqn,e0Test,e1Test,eGuess,ee,ratio},
+	(*See if the user specified some precision goal *)
+	If[Not@ValidAQ[a]||Not@ValidXQ[x]||Not@ValidResIntQ[0,\[Beta]\[Theta],\[Beta]\[Phi]],Abort[]];
+	
+	pg=OptionValue[PrecisionGoal];
+	ratio=\[Beta]\[Phi]/\[Beta]\[Theta];
+	If[x>0&&ratio<1, Message[KerrGeoFindResonance::invalidPrograde]; Abort[]];
+	If[x<0&&ratio>1, Message[KerrGeoFindResonance::invalidRetrograde]; Abort[]];
+	
+	(* Test to see if there is an eccentricity that will lead to a bound orbital resonance 
+	 based on the provided values of a, p, x *)
+	e0Test=KerrGeoOrbitPhiThetaResonantP[a,0,x,{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
+	e1Test=KerrGeoOrbitPhiThetaResonantP[a,1,x,{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
+	If[p<e0Test||e1Test<p, Message[KerrGeoFindResonance::noresonance, e0Test, e1Test]; Abort[];];
+	If[p==e0Test,Return[0]];
+	If[p==e1Test,Return[1]];
+	eGuess=(p-e0Test)/(e1Test-e0Test);
+
+	(* Resonant condition defined by the equation below *)
+	If[x==0,
+		If[ratio>1,
+			resonantEqn[e_?NumericQ]:= \[Phi]\[Theta]Ratio[a, p, e, x][[1]]-Abs[ratio],
+			resonantEqn[e_?NumericQ]:= \[Phi]\[Theta]Ratio[a, p, e, x][[2]]-Abs[ratio]
+		],
+		resonantEqn[e_?NumericQ]:= \[Phi]\[Theta]Ratio[a, p, e, x]-Abs[ratio]
+	];
+	
+	(* Working precision of the root-finding method is based on the precision specified
+	 by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
+	 is the default precision if not other precision specifications are made. *)
+	argpg=Precision[{resonantEqn[eGuess],a,p,x,ratio}];
+	If[argpg==$MachinePrecision,pg=argpg];
+	If[(Not@NumericQ[pg]||pg>argpg),pg=argpg];
+	If[pg==Infinity,pg=$MachinePrecision];
+
+	If[pg==$MachinePrecision,
+		Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess}]],
+		Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess},PrecisionGoal->pg,WorkingPrecision->pg]],
+		Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess},PrecisionGoal->pg,WorkingPrecision->pg]]
+	]
+];
+
+
+(* ::Subsubsection::Closed:: *)
+(*Given (a,p,e) and Subscript[\[CapitalOmega], \[Theta]]/Subscript[\[CapitalOmega], \[Phi]]= Subscript[\[Beta], \[Theta]]/Subscript[\[Beta], \[Phi]] find x*)
+
+
+Options[KerrGeoOrbitPhiThetaResonantX]={PrecisionGoal->Automatic};
+
+
+KerrGeoOrbitPhiThetaResonantX[a_?NumericQ, p_?NumericQ, e_?NumericQ, {\[Beta]\[Theta]_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
+Module[{pg,argpg,resonantEqn,x0Test, x1Test,xGuess,xx,ratio},
+	(* Test to see if there is an eccentricity that will lead to a bound orbital resonance 
+	based on the provided values of a, p, x *)
+	(*See if the user specified some precision goal *)
+	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidResIntQ[0,\[Beta]\[Theta],\[Beta]\[Phi]],Abort[]];
+
+	pg=OptionValue[PrecisionGoal];
+	ratio=\[Beta]\[Phi]/\[Beta]\[Theta];
+	(* Test to see if there is an inclination angle that will lead to a bound orbital resonance 
+	 based on the provided values of a, p, e *)
+	x0Test=KerrGeoOrbitPhiThetaResonantP[a,e,0,{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
+	x1Test=KerrGeoOrbitPhiThetaResonantP[a,e,Sign[ratio],{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
+	
+	If[ratio>1 && (p<x1Test||x0Test<p), Message[KerrGeoFindResonance::noresonance, x1Test, x0Test]; Abort[];];
+	If[ratio<1 && (p<x0Test||x1Test<p), Message[KerrGeoFindResonance::noresonance, x0Test, x1Test]; Abort[];];
+	If[p==x0Test,Return[0]];
+	If[p==x1Test,Return[Sign[ratio]]];
+	xGuess=Sign[ratio](p-x0Test)/(x1Test-x0Test);
+
+	(* Resonant condition defined by the equation below *)
+	resonantEqn[x_?NumericQ]:=\[Phi]\[Theta]Ratio[a, p, e, x]-Abs[ratio];
+	
+	(* Working precision of the root-finding method is based on the precision specified
+	 by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
+	 is the default precision if not other precision specifications are made. *)
+	argpg=Precision[{a,p,e,ratio}];
+	If[argpg==$MachinePrecision,pg=0.9argpg];
+	If[(Not@NumericQ[pg]||pg>argpg),pg=0.9argpg];
+	If[pg==Infinity,pg=$MachinePrecision];
+
+	If[pg==$MachinePrecision,
+		Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess}]],
+		Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess},PrecisionGoal->pg,WorkingPrecision->0.95argpg]],
+		Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess},PrecisionGoal->pg,WorkingPrecision->0.95argpg]]
+	]
+];
+
+
+(* ::Subsection::Closed:: *)
+(*r\[Theta]\[Phi]-resonance*)
+
+
+(* ::Subsubsection::Closed:: *)
+(*Testing functions*)
+
+
+(* ::Text:: *)
+(*Same as those of r\[Theta]-resonance*)
+
+
+(* ::Subsubsection::Closed:: *)
+(*Useful functions for root-finding*)
+
+
+(* ::Text:: *)
+(*Use those of double resonances*)
+
+
+(* ::Subsubsection:: *)
+(*Given (a,e,\[Beta]r,\[Beta]\[Theta]) find (\[Beta]rmin, \[Beta]rmax)*)
+
+
+Options[KerrGeoOrbitTripleResonant\[Beta]r]={PrecisionGoal->Automatic};
+
+
+KerrGeoOrbitTripleResonant\[Beta]r[a_?NumericQ, e_?NumericQ, {\[Beta]\[Theta]_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
+Module[{pg,argpg,resonantEqnr\[Theta],resonantEqnr\[Phi],p0Test,p1Test,r\[Theta]ratio0,r\[Theta]ratio1,\[Phi]\[Theta]ratio},
+	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidXQ[x]||Not@ValidResIntQ[0,\[Beta]\[Theta],\[Beta]\[Phi]],Abort[]];
+	\[Phi]\[Theta]ratio=\[Beta]\[Phi]/\[Beta]\[Theta];
+	p0Test=KerrGeoOrbitPhiThetaResonantP[a, e, 0, {\[Beta]\[Theta], \[Beta]\[Phi]}, opts];
+	p1Test=KerrGeoOrbitPhiThetaResonantP[a, e, Sign[\[Beta]\[Theta]], {\[Beta]\[Theta], \[Beta]\[Phi]}, opts];
+	r\[Theta]ratio0=Sign[\[Beta]\[Theta]]r\[Theta]Ratio[a, p0Test, e, 0];
+	r\[Theta]ratio1=Sign[\[Beta]\[Theta]]r\[Theta]Ratio[a, p1Test, e, Sign[\[Beta]\[Theta]]];
+	Sort[{\[Beta]\[Theta] r\[Theta]ratio0, \[Beta]\[Theta] r\[Theta]ratio1}, Less]
+];
+
+
+(* ::Subsubsection::Closed:: *)
+(*Given (a,e,\[Beta]r,\[Beta]\[Phi]) find (\[Beta]\[Theta]min, \[Beta]\[Theta]max)*)
+
+
+Options[KerrGeoOrbitTripleResonant\[Beta]\[Theta]]={PrecisionGoal->Automatic};
+
+
+KerrGeoOrbitTripleResonant\[Beta]\[Theta][a_?NumericQ, e_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
+Module[{pg,argpg,resonantEqnr\[Theta],resonantEqnr\[Phi],p0Test,p1Test,r\[Theta]ratio0,r\[Theta]ratio1,r\[Phi]ratio},
+	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,0,\[Beta]\[Phi]],Abort[]];
+	r\[Phi]ratio=\[Beta]r/\[Beta]\[Phi];
+	p0Test=KerrGeoOrbitRPhiResonantP[a, e, 0, {\[Beta]r, \[Beta]\[Phi]}, opts];
+	p1Test=KerrGeoOrbitRPhiResonantP[a, e, Sign[r\[Phi]ratio], {\[Beta]r, \[Beta]\[Phi]}, opts];
+	r\[Theta]ratio0=Sign[r\[Phi]ratio]r\[Theta]Ratio[a, p0Test, e, 0];
+	r\[Theta]ratio1=Sign[r\[Phi]ratio]r\[Theta]Ratio[a, p1Test, e, Sign[r\[Phi]ratio]];
+	Sort[{\[Beta]r/r\[Theta]ratio0, \[Beta]r/r\[Theta]ratio1}, Less]
+];
+
+
+(* ::Subsubsection::Closed:: *)
+(*Given (a,e,\[Beta]r,\[Beta]\[Theta]) find (\[Beta]\[Phi]min, \[Beta]\[Phi]max)*)
+
+
+Options[KerrGeoOrbitTripleResonant\[Beta]\[Phi]]={PrecisionGoal->Automatic};
+
+
+KerrGeoOrbitTripleResonant\[Beta]\[Phi][a_?NumericQ, e_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Theta]_Integer}, opts:OptionsPattern[]]:=
+Module[{pg,argpg,resonantEqnr\[Theta],resonantEqnr\[Phi],p0Test,p1Test,r\[Phi]ratio0,r\[Phi]ratio1,r\[Theta]ratio},
+	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Theta],0],Abort[]];
+	r\[Theta]ratio=\[Beta]r/\[Beta]\[Theta];
+	p0Test=KerrGeoOrbitRThetaResonantP[a, e, 0, {\[Beta]r, \[Beta]\[Theta]}, opts];
+	p1Test=KerrGeoOrbitRThetaResonantP[a, e, Sign[r\[Theta]ratio], {\[Beta]r, \[Beta]\[Theta]}, opts];
+	r\[Phi]ratio0=Sign[r\[Theta]ratio]If[r\[Theta]ratio>0, r\[Phi]Ratio[a, p0Test, e, 0][[1]], r\[Phi]Ratio[a, p0Test, e, 0][[2]]];
+	r\[Phi]ratio1=Sign[r\[Theta]ratio]r\[Phi]Ratio[a, p1Test, e, Sign[r\[Theta]ratio]];
+	Sort[{\[Beta]r/r\[Phi]ratio0, \[Beta]r/r\[Phi]ratio1}, Less]
+];
+
+
+(* ::Subsubsection::Closed:: *)
+(*Given (a,e,\[Beta]r,\[Beta]\[Theta],\[Beta]\[Phi]) find (p, x)*)
+
+
+Options[KerrGeoOrbitTripleResonantPX]={PrecisionGoal->Automatic};
+
+
+KerrGeoOrbitTripleResonantPX[a_?NumericQ, e_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Theta]_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
+Module[{pg,argpg,resonantEqnr\[Theta],resonantEqnr\[Phi],pGuess,xGuess,pp,xx,r\[Theta]ratio,r\[Phi]ratio,p0r\[Theta]Test,p1r\[Theta]Test,p0r\[Phi]Test,p1r\[Phi]Test,p0\[Phi]\[Theta]Test,p1\[Phi]\[Theta]Test,checkSolution, rInts, \[Theta]Ints, \[Phi]Ints},
+	(*See if the user specified some precision goal *)
+	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidXQ[x]||Not@ValidResIntQ[0,\[Beta]\[Theta],\[Beta]\[Phi]],Abort[]];
+	
+	pg=OptionValue[PrecisionGoal];
+	r\[Theta]ratio=\[Beta]r/\[Beta]\[Theta];
+	r\[Phi]ratio=\[Beta]r/\[Beta]\[Phi];
+	p0r\[Theta]Test=KerrGeoOrbitRThetaResonantP[a, e, 0, {\[Beta]r, \[Beta]\[Theta]},opts];
+	p1r\[Theta]Test=KerrGeoOrbitRThetaResonantP[a, e, Sign[r\[Theta]ratio], {\[Beta]r, \[Beta]\[Theta]},opts];
+	p0r\[Phi]Test=KerrGeoOrbitRPhiResonantP[a, e, 0, {\[Beta]r, \[Beta]\[Phi]},opts];
+	p1r\[Phi]Test=KerrGeoOrbitRPhiResonantP[a, e, Sign[r\[Phi]ratio], {\[Beta]r, \[Beta]\[Phi]},opts];
+	checkSolution=(p0r\[Theta]Test-p0r\[Phi]Test)(p1r\[Theta]Test-p1r\[Phi]Test);
+	If[checkSolution>0,
+		rInts=KerrGeoOrbitTripleResonant\[Beta]r[a, e, {\[Beta]\[Theta], \[Beta]\[Phi]}, opts];
+		\[Theta]Ints=KerrGeoOrbitTripleResonant\[Beta]\[Theta][a, e, {\[Beta]r, \[Beta]\[Phi]}, opts];
+		\[Phi]Ints=KerrGeoOrbitTripleResonant\[Beta]\[Phi][a, e, {\[Beta]r, \[Beta]\[Theta]}, opts];
+		Message[KerrGeoFindResonance::noTripleResonance,rInts[[1]],rInts[[2]],\[Theta]Ints[[1]],\[Theta]Ints[[2]],\[Phi]Ints[[1]],\[Phi]Ints[[2]]];
+		Abort[]];
+	
+	xGuess=Sign[r\[Theta]ratio]/((p1r\[Phi]Test-p1r\[Theta]Test)/(p0r\[Theta]Test-p0r\[Phi]Test)+1);
+	pGuess=p0r\[Theta]Test-Sign[r\[Theta]ratio]xGuess(p0r\[Theta]Test-p1r\[Theta]Test);
+	resonantEqnr\[Theta][p_?NumericQ, x_?NumericQ]:=r\[Theta]Ratio[a, p, e, x]-Abs[r\[Theta]ratio];
+	resonantEqnr\[Phi][p_?NumericQ, x_?NumericQ]:=r\[Phi]Ratio[a, p, e, x]-Abs[r\[Phi]ratio];
+	argpg=Precision[{a,e,r\[Theta]ratio,r\[Phi]ratio,resonantEqnr\[Theta][pGuess, xGuess],resonantEqnr\[Phi][pGuess, xGuess]}];
+	If[argpg==$MachinePrecision,pg=0.9argpg];
+	If[(Not@NumericQ[pg]||pg>argpg),pg=0.9argpg];
+	If[pg==Infinity,pg=$MachinePrecision];
+	If[pg==$MachinePrecision,
+		Re[{pp,xx}/.FindRoot[{resonantEqnr\[Theta][pp,xx],resonantEqnr\[Phi][pp,xx]},{{pp,pGuess},{xx,xGuess}}]],
+		Re[{pp,xx}/.FindRoot[{resonantEqnr\[Theta][pp,xx],resonantEqnr\[Phi][pp,xx]},{{pp,pGuess},{xx,xGuess}},PrecisionGoal->pg,WorkingPrecision->0.95argpg]],
+		Re[{pp,xx}/.FindRoot[{resonantEqnr\[Theta][pp,xx],resonantEqnr\[Phi][pp,xx]},{{pp,pGuess},{xx,xGuess}},PrecisionGoal->pg,WorkingPrecision->0.95argpg]]
+	]
+];
+
+
+(* ::Subsection::Closed:: *)
 (*Generic resonance interface*)
 
 
-Options[KerrGeoFindResonance]={PrecisionGoal->Automatic, Rotation->"Both"};
+Options[KerrGeoFindResonance]={PrecisionGoal->Automatic};
 
 
-KerrGeoFindResonance[assoc_Association,{\[Beta]r_Integer, \[Beta]\[Theta]_Integer, \[Beta]\[Phi]_Integer},opts:OptionsPattern[]]:= Module[{},Message[KerrGeoFindResonance::missing]; Return[$Failed]];
+KerrGeoFindResonance[assoc_Association,{\[Beta]r_Integer, \[Beta]\[Theta]_Integer, \[Beta]\[Phi]_Integer},opts:OptionsPattern[]]:=Module[{pp, xx},
+	If[ContainsExactly[Keys[assoc],{"a","e"}],
+		{pp, xx}=KerrGeoOrbitTripleResonantPX["a"/.assoc, "e"/.assoc, {\[Beta]r, \[Beta]\[Theta], \[Beta]\[Phi]}, opts];
+		{"p"->pp,"x"->xx},
+		Message[KerrGeoFindResonance::assocErrTriple]
+	]
+]
 
 KerrGeoFindResonance[assoc_Association,{\[Beta]r_Integer, \[Beta]\[Theta]_Integer, 0},opts:OptionsPattern[]]:=Block[{},
 	If[ContainsExactly[Keys[assoc],{"a","p","x"}],
@@ -977,6 +1187,19 @@ KerrGeoFindResonance[assoc_Association,{\[Beta]r_Integer, 0, \[Beta]\[Phi]_Integ
 			"p"->KerrGeoOrbitRPhiResonantP["a"/.assoc, "e"/.assoc, "x"/.assoc, {\[Beta]r, \[Beta]\[Phi]}, opts],
 			If[ContainsExactly[Keys[assoc],{"a","p","e"}],
 				"x"->KerrGeoOrbitRPhiResonantX["a"/.assoc, "p"/.assoc, "e"/.assoc, {\[Beta]r, \[Beta]\[Phi]}, opts],
+				Message[KerrGeoFindResonance::assocErr]
+			]
+		]
+	]
+]
+
+KerrGeoFindResonance[assoc_Association,{0, \[Beta]\[Theta]_Integer, \[Beta]\[Phi]_Integer},opts:OptionsPattern[]]:=Block[{},
+	If[ContainsExactly[Keys[assoc],{"a","p","x"}],
+		"e"->KerrGeoOrbitPhiThetaResonantE["a"/.assoc, "p"/.assoc, "x"/.assoc, {\[Beta]\[Theta], \[Beta]\[Phi]}, opts],
+		If[ContainsExactly[Keys[assoc],{"a","e","x"}],
+			"p"->KerrGeoOrbitPhiThetaResonantP["a"/.assoc, "e"/.assoc, "x"/.assoc, {\[Beta]\[Theta], \[Beta]\[Phi]}, opts],
+			If[ContainsExactly[Keys[assoc],{"a","p","e"}],
+				"x"->KerrGeoOrbitPhiThetaResonantX["a"/.assoc, "p"/.assoc, "e"/.assoc, {\[Beta]\[Theta], \[Beta]\[Phi]}, opts],
 				Message[KerrGeoFindResonance::assocErr]
 			]
 		]

--- a/Kernel/SpecialOrbits.m
+++ b/Kernel/SpecialOrbits.m
@@ -366,7 +366,7 @@ Return[pSep+10^(-5)];
 ];
 
 
-(* ::Subsection::Closed:: *)
+(* ::Subsection:: *)
 (*r\[Theta]-resonances*)
 
 
@@ -417,7 +417,7 @@ ValidResIntQ[0,\[Beta]\[Theta]_/;\[Beta]\[Theta]!=0,\[Beta]\[Phi]_/;\[Beta]\[Phi
 ];
 
 
-(* ::Subsubsection::Closed:: *)
+(* ::Subsubsection:: *)
 (*Useful functions for root-finding*)
 
 
@@ -525,7 +525,7 @@ Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest,pSep},
 ];
 
 
-(* ::Subsubsection::Closed:: *)
+(* ::Subsubsection:: *)
 (*Given (a,p,x) and Subscript[\[CapitalOmega], r]/Subscript[\[CapitalOmega], \[Theta]]= Subscript[\[Beta], r]/Subscript[\[Beta], \[Theta]] find e*)
 
 
@@ -569,7 +569,7 @@ Module[{pg,argpg,resonantEqn,e0Test,e1Test,eGuess,ee,ratio},
 ];
 
 
-(* ::Subsubsection::Closed:: *)
+(* ::Subsubsection:: *)
 (*Given (a,p,e) and Subscript[\[CapitalOmega], r]/Subscript[\[CapitalOmega], \[Theta]]= Subscript[\[Beta], r]/Subscript[\[Beta], \[Theta]] find x*)
 
 
@@ -613,7 +613,7 @@ Module[{pg,argpg,resonantEqn,x0Test,x1Test,xGuess,xx,xxx,ratio},
 ];
 
 
-(* ::Subsection::Closed:: *)
+(* ::Subsection:: *)
 (*r\[Phi]-resonances*)
 
 
@@ -724,7 +724,7 @@ Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest, pSep},
 ];
 
 
-(* ::Subsubsection::Closed:: *)
+(* ::Subsubsection:: *)
 (*Given (a,p,x) and Subscript[\[CapitalOmega], r]/Subscript[\[CapitalOmega], \[Phi]]= Subscript[\[Beta], r]/Subscript[\[Beta], \[Phi]] find e*)
 
 
@@ -775,7 +775,7 @@ Module[{pg,argpg,resonantEqn,e0Test,e1Test,eGuess,ee,ratio},
 ];
 
 
-(* ::Subsubsection::Closed:: *)
+(* ::Subsubsection:: *)
 (*Given (a,p,e) and Subscript[\[CapitalOmega], r]/Subscript[\[CapitalOmega], \[Phi]]= Subscript[\[Beta], r]/Subscript[\[Beta], \[Phi]] find x*)
 
 
@@ -826,7 +826,7 @@ Module[{pg,rtt,argpg,resonantEqn,x0Test, x1Test, x0Test1,x0Test2,x1Test1,x1Test2
 ];
 
 
-(* ::Subsection::Closed:: *)
+(* ::Subsection:: *)
 (*\[Phi]\[Theta]-resonance*)
 
 
@@ -890,7 +890,7 @@ Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest,pSep},
 ];
 
 
-(* ::Subsubsection::Closed:: *)
+(* ::Subsubsection:: *)
 (*Given (a,p,x) and Subscript[\[CapitalOmega], \[Phi]]/Subscript[\[CapitalOmega], \[Theta]]= Subscript[\[Beta], \[Phi]]/Subscript[\[Beta], \[Theta]] find e*)
 
 
@@ -941,7 +941,7 @@ Module[{pg,argpg,resonantEqn,e0Test,e1Test,eGuess,ee,ratio},
 ];
 
 
-(* ::Subsubsection::Closed:: *)
+(* ::Subsubsection:: *)
 (*Given (a,p,e) and Subscript[\[CapitalOmega], \[Theta]]/Subscript[\[CapitalOmega], \[Phi]]= Subscript[\[Beta], \[Theta]]/Subscript[\[Beta], \[Phi]] find x*)
 
 
@@ -960,13 +960,13 @@ Module[{pg,argpg,resonantEqn,x0Test, x1Test,xGuess,xx,ratio},
 	(* Test to see if there is an inclination angle that will lead to a bound orbital resonance 
 	 based on the provided values of a, p, e *)
 	x0Test=KerrGeoOrbitPhiThetaResonantP[a,e,0,{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
-	x1Test=KerrGeoOrbitPhiThetaResonantP[a,e,Sign[ratio],{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
+	x1Test=KerrGeoOrbitPhiThetaResonantP[a,e,Sign[ratio-1],{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
 	
 	If[ratio>1 && (p<x1Test||x0Test<p), Message[KerrGeoFindResonance::noresonance, x1Test, x0Test]; Abort[];];
 	If[ratio<1 && (p<x0Test||x1Test<p), Message[KerrGeoFindResonance::noresonance, x0Test, x1Test]; Abort[];];
 	If[p==x0Test,Return[0]];
 	If[p==x1Test,Return[Sign[ratio]]];
-	xGuess=Sign[ratio](p-x0Test)/(x1Test-x0Test);
+	xGuess=Sign[ratio-1](p-x0Test)/(x1Test-x0Test);
 
 	(* Resonant condition defined by the equation below *)
 	resonantEqn[x_?NumericQ]:=\[Phi]\[Theta]Ratio[a, p, e, x]-Abs[ratio];
@@ -987,7 +987,7 @@ Module[{pg,argpg,resonantEqn,x0Test, x1Test,xGuess,xx,ratio},
 ];
 
 
-(* ::Subsection::Closed:: *)
+(* ::Subsection:: *)
 (*r\[Theta]\[Phi]-resonance*)
 
 
@@ -1007,7 +1007,7 @@ Module[{pg,argpg,resonantEqn,x0Test, x1Test,xGuess,xx,ratio},
 (*Use those of double resonances*)
 
 
-(* ::Subsubsection:: *)
+(* ::Subsubsection::Closed:: *)
 (*Given (a,e,\[Beta]r,\[Beta]\[Theta]) find (\[Beta]rmin, \[Beta]rmax)*)
 
 

--- a/Kernel/SpecialOrbits.m
+++ b/Kernel/SpecialOrbits.m
@@ -8,7 +8,7 @@
 (*Define usage for public functions*)
 
 
-(* ::Section::Closed:: *)
+(* ::Section:: *)
 (*Create Package*)
 
 
@@ -42,7 +42,7 @@ KerrGeoPlungeOrbitQ::usage = "KerrGeoPlungeOrbitQ[a,p,e,x] tests if the orbital 
 
 
 KerrGeoFindResonance::noresonance = "Resonant orbits only occur for semi-latus rectum in range `1` \[LessEqual] p \[LessEqual] `2`"
-KerrGeoFindResonance::noTripleResonance = "Triple Resonant orbits occur for `1` \[LessEqual] r-integer \[LessEqual] `2`, `3` \[LessEqual] \[Theta]-integer \[LessEqual] `4` or `5` \[LessEqual] \[Phi]-integer \[LessEqual] `6`"
+KerrGeoFindResonance::noTripleResonance = "No triple resonance; try `1` \[LessEqual] r-integer \[LessEqual] `2`, `3` \[LessEqual] \[Theta]-integer \[LessEqual] `4` or `5` \[LessEqual] \[Phi]-integer \[LessEqual] `6`"
 KerrGeoFindResonance::invalida = "Invalid black hole spin parameter. Choose 0 < a \[LessEqual] 1."
 KerrGeoFindResonance::invalide = "Invalid orbital eccentricity. Choose 0 \[LessEqual] e \[LessEqual] 1."
 KerrGeoFindResonance::invalidx = "Invalid orbital inclination. Choose 0 \[LessEqual] |x| \[LessEqual] 1."
@@ -52,6 +52,7 @@ KerrGeoFindResonance::assocErrTriple = "Only support association {a, e} for inpu
 KerrGeoFindResonance::missing = "Resonaces involving the \[Phi] frequency are not yet implemented"
 KerrGeoFindResonance::invalidPrograde = "Invalid prograde resonant integers. Choose \[Beta]r/\[Beta]\[Phi] > 0, \[Beta]r/\[Beta]\[Phi] > 0 and \[Beta]\[Theta] < \[Beta]\[Phi]"
 KerrGeoFindResonance::invalidRetrograde = "Invalid retrograde resonant integers. Choose \[Beta]r/\[Beta]\[Phi] < 0, \[Beta]r/\[Beta]\[Phi] < 0 and \[Beta]\[Theta] > \[Beta]\[Phi]"  
+KerrGeoFindResonance::closeSeparatrix = "No resonance or the exact result is too close to the separatrix, the value is set to the separatrix+10^(-5) instead"
 
 
 (* ::Subsection::Closed:: *)
@@ -345,6 +346,27 @@ KerrGeoOrbitType[a_?NumericQ, p_?NumericQ, e_?NumericQ, x_?NumericQ]:=Module[{ou
 
 
 (* ::Subsection:: *)
+(*Resonance solver*)
+
+
+Options[ResonanceSolver]={PrecisionGoal->Automatic};
+
+
+ResonanceSolver[f_, {p_, p0_?NumericQ, pSep_?NumericQ}, opts:OptionsPattern[]]:=
+Module[{pp},
+If[p0<pSep,
+	Quiet[Check[Return[p/.FindRoot[f[p], {p, pSep+10^(-5), pSep, Infinity}]],{}]];
+	Message[KerrGeoFindResonance::closeSeparatrix];
+	Return[pSep+10^(-5)];
+];
+Quiet[Check[Return[p/.FindRoot[f[p], {p, p0, pSep, Infinity}]],{}]];
+Quiet[Check[Return[p/.FindRoot[f[p], {p, pSep+10^(-5), pSep, Infinity}]],{}]];
+Message[KerrGeoFindResonance::closeSeparatrix];
+Return[pSep+10^(-5)];
+];
+
+
+(* ::Subsection::Closed:: *)
 (*r\[Theta]-resonances*)
 
 
@@ -433,16 +455,16 @@ y1y2[0,p_,e_,x_/;x^2<1]:=y1y2[0,p,e,1];
 
 \[Pi]x[a_,p_,e_,x_/;x>=0]:=(a^2*(1 - x^2)*((-4 + p)*p^7 + a^8*(-1 + e^2)^4*(-1 + x^2)^2 + 2*a^6*(-1 + e^2)^2*p*(1 - x^2)*((1 + e^2)*p + (-2 + p + e^2*(2 + p))*(1 - x^2)) + 
    a^4*p^3*((-3 + 2*e^2 + e^4)*p + 4*(-4 + 3*p + e^4*(4 + p))*(1 - x^2) + (-1 + e^2)*(-4 + e^2*(-12 + p) + 3*p)*(-1 + x^2)^2) + 
-   2*a^2*p^2*((-1 - e^2)*p^4*(-2 + x^2) + 8*(-1 + e^2)*p^2*(-1 + x^2) + 2*p^3*(-3 - e^2 + 4*(1 + e^2)*x^2) + 
-     4*(-1 + x^2)*Sqrt[-(((a^4*(-1 + e^2)^2 + (-4*e^2 + (-2 + p)^2)*p^2 + 2*a^2*p*(-2 + p + e^2*(2 + p)))*x^2*(-p^2 + a^2*(-1 + e)^2*(-1 + x^2))*(-p^2 + a^2*(1 + e)^2*(-1 + x^2))*
-          (-p^2 + a^2*(-1 + e^2)*(-1 + x^2)))/(a^2*p*(-1 + x^2)^2))])))/((-4 + p)^2*p^6 + a^8*(-1 + e^2)^4*(-1 + x^2)^2 + 2*a^2*p^5*((-1 + e^2)*(4 + p) + (-4 + e^2*(-12 + p) + 3*p)*(1 - x^2)) + 
+   2*a^2*p^2*((-1 - e^2)*p^4*(-2 + x^2) + 8*(-1 + e^2)*p^2*(-1 + x^2) + 2*p^3*(-3 - e^2 + 4*(1 + e^2)*x^2) - 
+     4*Sqrt[-1/(a^2*p)(((a^4*(-1 + e^2)^2 + (-4*e^2 + (-2 + p)^2)*p^2 + 2*a^2*p*(-2 + p + e^2*(2 + p)))*x^2*(-p^2 + a^2*(-1 + e)^2*(-1 + x^2))*(-p^2 + a^2*(1 + e)^2*(-1 + x^2))*
+          (-p^2 + a^2*(-1 + e^2)*(-1 + x^2))))])))/((-4 + p)^2*p^6 + a^8*(-1 + e^2)^4*(-1 + x^2)^2 + 2*a^2*p^5*((-1 + e^2)*(4 + p) + (-4 + e^2*(-12 + p) + 3*p)*(1 - x^2)) + 
   2*a^6*(-1 + e^2)^2*p^2*(-1 + x^2)*(-2 + 3*x^2 + e^2*(-2 + x^2)) + a^4*p^3*(-8*(-1 + e^2)^2*(1 - 3*x^2 + 2*x^4) + p*((-1 + e^2)^2 - 4*(-1 + e^4)*(-1 + x^2) + (3 + e^2)^2*(-1 + x^2)^2)));
 
 \[Pi]x[a_,p_,e_,x_/;x<0]:=(a^2*(1 - x^2)*((-4 + p)*p^7 + a^8*(-1 + e^2)^4*(-1 + x^2)^2 + 2*a^6*(-1 + e^2)^2*p*(1 - x^2)*((1 + e^2)*p + (-2 + p + e^2*(2 + p))*(1 - x^2)) + 
    a^4*p^3*((-3 + 2*e^2 + e^4)*p + 4*(-4 + 3*p + e^4*(4 + p))*(1 - x^2) + (-1 + e^2)*(-4 + e^2*(-12 + p) + 3*p)*(-1 + x^2)^2) + 
-   2*a^2*p^2*(-((1 + e^2)*p^4*(-2 + x^2)) + 8*(-1 + e^2)*p^2*(-1 + x^2) + 2*p^3*(-3 - e^2 + 4*(1 + e^2)*x^2) - 
-     4*(-1 + x^2)*Sqrt[-(((a^4*(-1 + e^2)^2 + (-4*e^2 + (-2 + p)^2)*p^2 + 2*a^2*p*(-2 + p + e^2*(2 + p)))*x^2*(-p^2 + a^2*(-1 + e)^2*(-1 + x^2))*(-p^2 + a^2*(1 + e)^2*(-1 + x^2))*
-          (-p^2 + a^2*(-1 + e^2)*(-1 + x^2)))/(a^2*p*(-1 + x^2)^2))])))/((-4 + p)^2*p^6 + a^8*(-1 + e^2)^4*(-1 + x^2)^2 + 2*a^2*p^5*((-1 + e^2)*(4 + p) + (-4 + e^2*(-12 + p) + 3*p)*(1 - x^2)) + 
+   2*a^2*p^2*(-((1 + e^2)*p^4*(-2 + x^2)) + 8*(-1 + e^2)*p^2*(-1 + x^2) + 2*p^3*(-3 - e^2 + 4*(1 + e^2)*x^2) + 
+     4*Sqrt[-1/(a^2*p)(((a^4*(-1 + e^2)^2 + (-4*e^2 + (-2 + p)^2)*p^2 + 2*a^2*p*(-2 + p + e^2*(2 + p)))*x^2*(-p^2 + a^2*(-1 + e)^2*(-1 + x^2))*(-p^2 + a^2*(1 + e)^2*(-1 + x^2))*
+          (-p^2 + a^2*(-1 + e^2)*(-1 + x^2))))])))/((-4 + p)^2*p^6 + a^8*(-1 + e^2)^4*(-1 + x^2)^2 + 2*a^2*p^5*((-1 + e^2)*(4 + p) + (-4 + e^2*(-12 + p) + 3*p)*(1 - x^2)) + 
   2*a^6*(-1 + e^2)^2*p^2*(-1 + x^2)*(-2 + 3*x^2 + e^2*(-2 + x^2)) + a^4*p^3*(-8*(-1 + e^2)^2*(1 - 3*x^2 + 2*x^4) + p*((-1 + e^2)^2 - 4*(-1 + e^4)*(-1 + x^2) + (3 + e^2)^2*(-1 + x^2)^2)));
 
 
@@ -482,7 +504,8 @@ Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest,pSep},
 	If[x<0&&ratio>0, Message[KerrGeoFindResonance::invalidRetrograde]; Abort[]];
 	(* pStar provides an initial guess for p. Note that p = pStar for e = 0 and a = 0*)
 	pStar=6/(1-ratio^2); (* See Eq 30 *)
-
+	pSep=KerrGeoSeparatrix[a,e,x];
+	
 	(* Resonant condition defined by the equation below *)
 	resonantEqn[p_?NumericQ]:=r\[Theta]Ratio[a, p, e, x]-Abs[ratio];
 	
@@ -493,11 +516,11 @@ Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest,pSep},
 	If[argpg==$MachinePrecision,pg=argpg];
 	If[(Not@NumericQ[pg]||pg>argpg),pg=argpg];
 	If[pg==Infinity,pg=$MachinePrecision];
-
+	
 	If[pg==$MachinePrecision,
-		Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar}]],
-		Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar},PrecisionGoal->pg,WorkingPrecision->pg]],
-		Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar},PrecisionGoal->pg,WorkingPrecision->pg]]
+		ResonanceSolver[resonantEqn,{pp, pStar, pSep}],
+		ResonanceSolver[resonantEqn,{pp, pStar, pSep, PrecisionGoal->pg, WorkingPrecision->pg}],
+		ResonanceSolver[resonantEqn,{pp, pStar, pSep, PrecisionGoal->pg, WorkingPrecision->pg}]
 	]
 ];
 
@@ -590,7 +613,7 @@ Module[{pg,argpg,resonantEqn,x0Test,x1Test,xGuess,xx,xxx,ratio},
 ];
 
 
-(* ::Subsection:: *)
+(* ::Subsection::Closed:: *)
 (*r\[Phi]-resonances*)
 
 
@@ -602,73 +625,61 @@ Module[{pg,argpg,resonantEqn,x0Test,x1Test,xGuess,xx,xxx,ratio},
 (*Same as those of r\[Theta]-resonance*)
 
 
-(* ::Subsubsection:: *)
+(* ::Subsubsection::Closed:: *)
 (*Useful functions for root-finding*)
 
 
-r\[Phi]Ratio[a_, p_, e_, x_/;x!=0]:= Sign[x] ("\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(r\)]\)")/("\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Phi]\)]\)")/.KerrGeoFrequencies[a, p, e, x, Time->"Mino"]
+En2[a_, p_, e_/;e<1, x_]:=1-(2(1-e^2))/(2p+(1-e^2)\[Pi]p[a,p,e,x]);
+En2[a_,p_,1, x_]:=1;
+
+L2[a_, p_, e_, x_]:=(2 (a^2 (-1+e^2)+p^2) (a^2-\[Pi]x[a,p,e,x])+4 a^2 p \[Pi]p[a,p,e,x])/(a^2 (2 p+(1-e^2)\[Pi]p[a,p,e,x]));
+L2[a_, p_, e_, 0]:=0;
+
+Q[a_, p_, e_, x_/;x^2<1]:=(2 p^2 \[Pi]x[a,p,e,x])/(a^2 (2 p+(1-e^2)\[Pi]p[a,p,e,x]));
+Q[a_, p_, e_, x_/;x^2==1]:=0;
+
+r3[a_, p_, e_, x_/;x^2<1]:=(\[Pi]p[a,p,e,x]+Sqrt[\[Pi]p[a,p,e,x]^2-4 \[Pi]x[a,p,e,x]])/2;
+r3[a_, p_, e_, x_/;x^2==1]:=\[Pi]p[a,p,e,x];
+
+r4[a_, p_, e_, x_/;x^2<1]:=(\[Pi]p[a,p,e,x]-Sqrt[\[Pi]p[a,p,e,x]^2-4 \[Pi]x[a,p,e,x]])/2;
+r4[a_, p_, e_, x_/;x^2==1]:=0;
 
 
-r\[Phi]Ratio[a_, p_, e_/;e<1, x_/;x==0]:=
-Module[{S, P, r1, r2, r3, r4, EnSquared, Q, kr, k\[Theta], factor1, factor2, rPlus, rMinus, hPlus, hMinus, hr, BrPlus, BrMinus, Br, r\[Theta]Ratio},
-	(* S=r3+r4, P=r3*r4 *)
-	P = (a^2(a^4(-1+e^2)2+p^4+2a^2p(-2+p+e^2(2+p))))/(a^4(-1+e^2)^2+2a^2(1+e^2)p^2+(-4+p)p^3);
-	S = (2(a^2(-1+e^2)+p^2)^2)/(a^4(-1+e^2)^2+2a^2(1+e^2)p^2+(-4+p)p^3);
-	EnSquared = 1+2(-1+e^2)/(2p+S-e^2S);
-    Q = 2p^2P/(a^2(2p+S-e^2S));
-    r1 = p/(1-e);
-    r2 = p/(1+e);
-    r3 = (S+Sqrt[S^2-4P])/2;
-    r4 = (S-Sqrt[S^2-4P])/2;
-    kr = Abs[(r1-r2)/(r1-r3)(r3-r4)/(r2-r4)];
-    k\[Theta] = Abs[(1-EnSquared)a^2/Q];
-    factor1 = Sqrt[(r1-r3)(r2-r4)2(1-e^2)a^2/(2p^2P)];
-    r\[Theta]Ratio = factor1 EllipticK[k\[Theta]]/EllipticK[kr];
-    
-    rPlus = 1+Sqrt[1-a^2];
-    rMinus = 1-Sqrt[1-a^2];
-    hr = (r1-r2)/(r1-r3);
-    hPlus = hr (r3-rPlus)/(r2-rPlus);
-    hMinus = hr (r3-rMinus)/(r2-rMinus);
-    factor2 = 2a/(Pi(rPlus-rMinus)Sqrt[(1-EnSquared)(r1-r3)(r2-r4)])2Sqrt[EnSquared];
-    BrPlus = rPlus/(r3-rPlus)(EllipticK[kr]-(r2-r3)/(r2-rPlus)EllipticPi[hPlus, kr]);
-    BrMinus = rMinus/(r3-rMinus)(EllipticK[kr]-(r2-r3)/(r2-rMinus)EllipticPi[hPlus, kr]);
-    Br = factor2(BrPlus-BrMinus);
-    (* {prograde, retrograde} *)
-    {1/(1/r\[Theta]Ratio+Br),-1/(-1/r\[Theta]Ratio+Br)}
-];
+\[Pi]xReduced[a_,p_,e_,x_/;x>=0]:=(a^2*((-4 + p)*p^7 + a^8*(-1 + e^2)^4*(-1 + x^2)^2 + 2*a^6*(-1 + e^2)^2*p*(1 - x^2)*((1 + e^2)*p + (-2 + p + e^2*(2 + p))*(1 - x^2)) + 
+   a^4*p^3*((-3 + 2*e^2 + e^4)*p + 4*(-4 + 3*p + e^4*(4 + p))*(1 - x^2) + (-1 + e^2)*(-4 + e^2*(-12 + p) + 3*p)*(-1 + x^2)^2) + 
+   2*a^2*p^2*((-1 - e^2)*p^4*(-2 + x^2) + 8*(-1 + e^2)*p^2*(-1 + x^2) + 2*p^3*(-3 - e^2 + 4*(1 + e^2)*x^2) - 
+     4*Sqrt[-1/(a^2*p)(((a^4*(-1 + e^2)^2 + (-4*e^2 + (-2 + p)^2)*p^2 + 2*a^2*p*(-2 + p + e^2*(2 + p)))*x^2*(-p^2 + a^2*(-1 + e)^2*(-1 + x^2))*(-p^2 + a^2*(1 + e)^2*(-1 + x^2))*
+          (-p^2 + a^2*(-1 + e^2)*(-1 + x^2))))])))/((-4 + p)^2*p^6 + a^8*(-1 + e^2)^4*(-1 + x^2)^2 + 2*a^2*p^5*((-1 + e^2)*(4 + p) + (-4 + e^2*(-12 + p) + 3*p)*(1 - x^2)) + 
+  2*a^6*(-1 + e^2)^2*p^2*(-1 + x^2)*(-2 + 3*x^2 + e^2*(-2 + x^2)) + a^4*p^3*(-8*(-1 + e^2)^2*(1 - 3*x^2 + 2*x^4) + p*((-1 + e^2)^2 - 4*(-1 + e^4)*(-1 + x^2) + (3 + e^2)^2*(-1 + x^2)^2)));
+\[Pi]xReduced[a_,p_,e_,x_/;x<0]:=(a^2*((-4 + p)*p^7 + a^8*(-1 + e^2)^4*(-1 + x^2)^2 + 2*a^6*(-1 + e^2)^2*p*(1 - x^2)*((1 + e^2)*p + (-2 + p + e^2*(2 + p))*(1 - x^2)) + 
+   a^4*p^3*((-3 + 2*e^2 + e^4)*p + 4*(-4 + 3*p + e^4*(4 + p))*(1 - x^2) + (-1 + e^2)*(-4 + e^2*(-12 + p) + 3*p)*(-1 + x^2)^2) + 
+   2*a^2*p^2*(-((1 + e^2)*p^4*(-2 + x^2)) + 8*(-1 + e^2)*p^2*(-1 + x^2) + 2*p^3*(-3 - e^2 + 4*(1 + e^2)*x^2) + 
+     4*Sqrt[-1/(a^2*p)(((a^4*(-1 + e^2)^2 + (-4*e^2 + (-2 + p)^2)*p^2 + 2*a^2*p*(-2 + p + e^2*(2 + p)))*x^2*(-p^2 + a^2*(-1 + e)^2*(-1 + x^2))*(-p^2 + a^2*(1 + e)^2*(-1 + x^2))*
+          (-p^2 + a^2*(-1 + e^2)*(-1 + x^2))))])))/((-4 + p)^2*p^6 + a^8*(-1 + e^2)^4*(-1 + x^2)^2 + 2*a^2*p^5*((-1 + e^2)*(4 + p) + (-4 + e^2*(-12 + p) + 3*p)*(1 - x^2)) + 
+  2*a^6*(-1 + e^2)^2*p^2*(-1 + x^2)*(-2 + 3*x^2 + e^2*(-2 + x^2)) + a^4*p^3*(-8*(-1 + e^2)^2*(1 - 3*x^2 + 2*x^4) + p*((-1 + e^2)^2 - 4*(-1 + e^4)*(-1 + x^2) + (3 + e^2)^2*(-1 + x^2)^2)));
 
 
-r\[Phi]Ratio[a_, p_, e_/;e==1, x_/;x==0]:=
-Module[{S, P, r1, r2, r3, r4, EnSquared, Q, kr, k\[Theta], factor1, factor2, rPlus, rMinus, hPlus, hMinus, hr, BrPlus, BrMinus, Br, r\[Theta]Ratio},
-	(* S=r3+r4, P=r3*r4 *)
-	P = (a^2 (4 a^2 p^2+p^4))/(4 a^2 p^2+(-4+p) p^3);
-	S = (2 p^4)/(4 a^2 p^2 + (-4 + p) p^3);
-	EnSquared = 1;
-    Q = 2p^2P/(a^2 2p);
-    (* r1=p/(1-e) diverges *)
-    r2 = p/2;
-    r3 = (S+Sqrt[S^2-4P])/2;
-    r4 = (S-Sqrt[S^2-4P])/2;
-    kr = (r3-r4)/(r2-r4);
-    k\[Theta] = (1-EnSquared)a^2/Q;
-    factor1 = Sqrt[(2p)(r2-r4)2a^2/(2p^2P)];
-    r\[Theta]Ratio = factor1 EllipticK[k\[Theta]]/EllipticK[kr];
-    
-    rPlus = 1+Sqrt[1-a^2];
-    rMinus = 1-Sqrt[1-a^2];
-    hPlus = (r3-rPlus)/(r2-rPlus);
-    hMinus = (r3-rMinus)/(r2-rMinus);
-    factor2 = 2a/(Pi(rPlus-rMinus)Sqrt[2(r2-r4)])2Sqrt[EnSquared];
-    BrPlus = rPlus/(r3-rPlus)(EllipticK[kr]-(r2-r3)/(r2-rPlus)EllipticPi[hPlus, kr]);
-    BrMinus = rMinus/(r3-rMinus)(EllipticK[kr]-(r2-r3)/(r2-rMinus)EllipticPi[hPlus, kr]);
-    Br = factor2(BrPlus-BrMinus);
-    (* {prograde, retrograde} *)
-    {1/(1/r\[Theta]Ratio+Br),-1/(-1/r\[Theta]Ratio+Br)}
-];
+kr[a_,p_,e_,x_]:=(p-p (1-e)/(1+e))/(p-r3[a,p,e,x](1-e))(r3[a,p,e,x]-r4[a,p,e,x])/(p/(1+e)-r4[a,p,e,x])
+k\[Theta][a_,p_,e_,x_]:=(1-x^2)(1-e^2)a^4/(p^2 \[Pi]xReduced[a,p,e,x]);
+rPlus[a_]:=1+Sqrt[1-a^2];
+rMinus[a_]:=1-Sqrt[1-a^2];
+hPlus[a_,p_,e_,x_]:=(p-p (1-e)/(1+e))/(p-r3[a,p,e,x](1-e))(r3[a,p,e,x]-rPlus[a])/(p/(1+e)-rPlus[a]);
+hMinus[a_,p_,e_,x_]:=(p-p (1-e)/(1+e))/(p-r3[a,p,e,x](1-e))(r3[a,p,e,x]-rMinus[a])/(p/(1+e)-rMinus[a]);
+prefactor\[Theta][a_,p_,e_,x_]:=2/Pi Sqrt[((a^2(-1+e^2)+p^2)(a^2-\[Pi]x[a,p,e,x])+2 a^2 p \[Pi]p[a,p,e,x])/(p^2 \[Pi]xReduced[a,p,e,x])];
+prefactorR[a_,p_,e_,x_]:=2a/(Pi(rPlus[a]-rMinus[a])) Sqrt[(2p+(1-e^2)\[Pi]p[a,p,e,x])/(2(p-r3[a,p,e,x](1-e))(p-r4[a,p,e,x](1+e)))];
+termRPlus[a_,p_,e_,x_]:=(2Sqrt[En2[a,p,e,x]] rPlus[a]-a Sign[x] Sqrt[L2[a,p,e,x]])/(r3[a,p,e,x]-rPlus[a])(EllipticK[kr[a,p,e,x]]-(p/(1+e)-r3[a,p,e,x])/(p/(1+e)-rPlus[a])EllipticPi[hPlus[a,p,e,x], kr[a,p,e,x]]);
+termRMinus[a_,p_,e_,x_]:=(2Sqrt[En2[a,p,e,x]] rMinus[a]-a Sign[x] Sqrt[L2[a,p,e,x]])/(r3[a,p,e,x]-rMinus[a])(EllipticK[kr[a,p,e,x]]-(p/(1+e)-r3[a,p,e,x])/(p/(1+e)-rMinus[a])EllipticPi[hMinus[a,p,e,x], kr[a,p,e,x]]);
 
 
-(* ::Subsubsection:: *)
+term\[Theta][a_,p_,e_,x_]:=prefactor\[Theta][a,p,e,x] EllipticPi[1-x^2, k\[Theta][a,p,e,x]];
+termR[a_,p_,e_,x_]:=prefactorR[a,p,e,x](termRPlus[a,p,e,x]-termRMinus[a,p,e,x]);
+
+
+r\[Phi]Ratio[a_, p_, e_, x_/;x!=0]:=Sign[x]/(Sign[x] term\[Theta][a,p,e,x]/r\[Theta]Ratio[a,p,e,x]+termR[a,p,e,x]);
+r\[Phi]Ratio[a_, p_, e_, x_/;x==0]:={1/(1/r\[Theta]Ratio[a,p,e,x]+termR[a,p,e,x]),-1/(-1/r\[Theta]Ratio[a,p,e,x]+termR[a,p,e,x])};
+
+
+(* ::Subsubsection::Closed:: *)
 (*Given (a,e,x) and Subscript[\[CapitalOmega], r]/Subscript[\[CapitalOmega], \[Phi]]= Subscript[\[Beta], r]/Subscript[\[Beta], \[Phi]] find p*)
 
 
@@ -676,7 +687,7 @@ Options[KerrGeoOrbitRPhiResonantP]={PrecisionGoal->Automatic};
 
 
 KerrGeoOrbitRPhiResonantP[a_?NumericQ, e_?NumericQ, x_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
-Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest},
+Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest, pSep},
 	(*See if the user specified some precision goal *)
 	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,0,\[Beta]\[Phi]],Abort[]];
 	
@@ -686,6 +697,7 @@ Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest},
 	If[x<0&&ratio>0, Message[KerrGeoFindResonance::invalidRetrograde]; Abort[]];
 	(* pStar provides an initial guess for p. Note that p = pStar for e = 0 and a = 0*)
 	pStar=6/(1-ratio^2);
+	pSep=KerrGeoSeparatrix[a,e,x];
 	
 	(* Resonant condition defined by the equation below *)
 	If[x==0,
@@ -705,9 +717,9 @@ Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest},
 	If[pg==Infinity,pg=$MachinePrecision];
 	
 	If[pg==$MachinePrecision,
-		Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar}]],
-		Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar},PrecisionGoal->pg,WorkingPrecision->pg]],
-		Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar},PrecisionGoal->pg,WorkingPrecision->pg]]
+		ResonanceSolver[resonantEqn,{pp, pStar, pSep}],
+		ResonanceSolver[resonantEqn,{pp, pStar, pSep, PrecisionGoal->pg, WorkingPrecision->pg}],
+		ResonanceSolver[resonantEqn,{pp, pStar, pSep, PrecisionGoal->pg, WorkingPrecision->pg}]
 	]
 ];
 
@@ -814,11 +826,11 @@ Module[{pg,rtt,argpg,resonantEqn,x0Test, x1Test, x0Test1,x0Test2,x1Test1,x1Test2
 ];
 
 
-(* ::Subsection:: *)
+(* ::Subsection::Closed:: *)
 (*\[Phi]\[Theta]-resonance*)
 
 
-(* ::Subsubsection:: *)
+(* ::Subsubsection::Closed:: *)
 (*Testing functions*)
 
 
@@ -830,66 +842,8 @@ Module[{pg,rtt,argpg,resonantEqn,x0Test, x1Test, x0Test1,x0Test2,x1Test1,x1Test2
 (*Useful functions for root-finding*)
 
 
-\[Phi]\[Theta]Ratio[a_, p_, e_, x_/;x!=0]:=Sign[x] ("\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Phi]\)]\)")/("\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Theta]\)]\)")/.KerrGeoFrequencies[a, p, e, x, Time->"Mino"]
-
-
-\[Phi]\[Theta]Ratio[a_, p_, e_/;e!=1, x_/;x==0]:=
-Module[{S, P, r1, r2, r3, r4, EnSquared, Q, kr, k\[Theta], factor1, factor2, rPlus, rMinus, hPlus, hMinus, hr, BrPlus, BrMinus, Br, r\[Theta]Ratio},
-	(* S=r3+r4, P=r3*r4 *)
-	P = (a^2(a^4(-1+e^2)2+p^4+2a^2p(-2+p+e^2(2+p))))/(a^4(-1+e^2)^2+2a^2(1+e^2)p^2+(-4+p)p^3);
-	S = (2(a^2(-1+e^2)+p^2)^2)/(a^4(-1+e^2)^2+2a^2(1+e^2)p^2+(-4+p)p^3);
-	EnSquared = 1+2(-1+e^2)/(2p+S-e^2S);
-    Q = 2p^2P/(a^2(2p+S-e^2S));
-    r1 = p/(1-e);
-    r2 = p/(1+e);
-    r3 = (S+Sqrt[S^2-4P])/2;
-    r4 = (S-Sqrt[S^2-4P])/2;
-    kr = (r1-r2)/(r1-r3)(r3-r4)/(r2-r4);
-    k\[Theta] = (1-EnSquared)a^2/Q;
-    factor1 = Sqrt[(r1-r3)(r2-r4)2(1-e^2)a^2/(2p^2P)];
-    r\[Theta]Ratio = factor1 EllipticK[k\[Theta]]/EllipticK[kr];
-    
-    rPlus = 1+Sqrt[1-a^2];
-    rMinus = 1-Sqrt[1-a^2];
-    hr = (r1-r2)/(r1-r3);
-    hPlus = hr (r3-rPlus)/(r2-rPlus);
-    hMinus = hr (r3-rMinus)/(r2-rMinus);
-    factor2 = 2a/(Pi(rPlus-rMinus)Sqrt[(1-EnSquared)(r1-r3)(r2-r4)])2Sqrt[EnSquared];
-    BrPlus = rPlus/(r3-rPlus)(EllipticK[kr]-(r2-r3)/(r2-rPlus)EllipticPi[hPlus, kr]);
-    BrMinus = rMinus/(r3-rMinus)(EllipticK[kr]-(r2-r3)/(r2-rMinus)EllipticPi[hPlus, kr]);
-    Br = factor2(BrPlus-BrMinus);
-    (* {prograde, retrograde} *)
-    {1+Br r\[Theta]Ratio, 1-Br r\[Theta]Ratio}
-];
-
-
-\[Phi]\[Theta]Ratio[a_, p_, e_/;e==1, x_/;x==0]:=
-Module[{S, P, r1, r2, r3, r4, EnSquared, Q, kr, k\[Theta], factor1, factor2, rPlus, rMinus, hPlus, hMinus, hr, BrPlus, BrMinus, Br, r\[Theta]Ratio},
-	(* S=r3+r4, P=r3*r4 *)
-	P = (a^2 (4 a^2 p^2+p^4))/(4 a^2 p^2+(-4+p) p^3);
-	S = (2 p^4)/(4 a^2 p^2 + (-4 + p) p^3);
-	EnSquared = 1;
-    Q = 2p^2P/(a^2 2p);
-    (* r1=p/(1-e) diverges *)
-    r2 = p/2;
-    r3 = (S+Sqrt[S^2-4P])/2;
-    r4 = (S-Sqrt[S^2-4P])/2;
-    kr = (r3-r4)/(r2-r4);
-    k\[Theta] = (1-EnSquared)a^2/Q;
-    factor1 = Sqrt[(2p)(r2-r4)2a^2/(2p^2P)];
-    r\[Theta]Ratio = factor1 EllipticK[k\[Theta]]/EllipticK[kr];
-    
-    rPlus = 1+Sqrt[1-a^2];
-    rMinus = 1-Sqrt[1-a^2];
-    hPlus = (r3-rPlus)/(r2-rPlus);
-    hMinus = (r3-rMinus)/(r2-rMinus);
-    factor2 = 2a/(Pi(rPlus-rMinus)Sqrt[2(r2-r4)])2Sqrt[EnSquared];
-    BrPlus = rPlus/(r3-rPlus)(EllipticK[kr]-(r2-r3)/(r2-rPlus)EllipticPi[hPlus, kr]);
-    BrMinus = rMinus/(r3-rMinus)(EllipticK[kr]-(r2-r3)/(r2-rMinus)EllipticPi[hPlus, kr]);
-    Br = factor2(BrPlus-BrMinus);
-    (* {prograde, retrograde} *)
-    {1+Br r\[Theta]Ratio, 1-Br r\[Theta]Ratio}
-];
+\[Phi]\[Theta]Ratio[a_, p_, e_, x_/;x!=0]:=term\[Theta][a,p,e,x]+Sign[x]r\[Theta]Ratio[a,p,e,x]termR[a,p,e,x];
+\[Phi]\[Theta]Ratio[a_, p_, e_, x_/;x==0]:={1+r\[Theta]Ratio[a,p,e,x]termR[a,p,e,x],1-r\[Theta]Ratio[a,p,e,x]termR[a,p,e,x]};
 
 
 (* ::Subsubsection::Closed:: *)
@@ -900,7 +854,7 @@ Options[KerrGeoOrbitPhiThetaResonantP]={PrecisionGoal->Automatic};
 
 
 KerrGeoOrbitPhiThetaResonantP[a_?NumericQ, e_?NumericQ, x_?NumericQ, {\[Beta]\[Theta]_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
-Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest},
+Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest,pSep},
 	(*See if the user specified some precision goal *)
 	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidXQ[x]||Not@ValidResIntQ[0,\[Beta]\[Theta],\[Beta]\[Phi]],Abort[]];
 	
@@ -910,7 +864,7 @@ Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest},
 	If[x<0&&ratio>1, Message[KerrGeoFindResonance::invalidRetrograde]; Abort[]];
 	(* pStar provides an initial guess for p. Note that p = pStar for e = 0*)
 	pStar=(2 a/Abs[ratio-1])^(2/3);
-
+	pSep=KerrGeoSeparatrix[a,e,x];
 	(* Resonant condition defined by the equation below *)
 	If[x==0,
 		If[ratio>1,
@@ -929,9 +883,9 @@ Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest},
 	If[pg==Infinity,pg=$MachinePrecision];
 	
 	If[pg==$MachinePrecision,
-		Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar}]],
-		Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar},PrecisionGoal->pg,WorkingPrecision->pg]],
-		Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar},PrecisionGoal->pg,WorkingPrecision->pg]]
+		ResonanceSolver[resonantEqn,{pp, pStar, pSep}],
+		ResonanceSolver[resonantEqn,{pp, pStar, pSep, PrecisionGoal->pg, WorkingPrecision->pg}],
+		ResonanceSolver[resonantEqn,{pp, pStar, pSep, PrecisionGoal->pg, WorkingPrecision->pg}]
 	]
 ];
 
@@ -1057,10 +1011,10 @@ Module[{pg,argpg,resonantEqn,x0Test, x1Test,xGuess,xx,ratio},
 (*Given (a,e,\[Beta]r,\[Beta]\[Theta]) find (\[Beta]rmin, \[Beta]rmax)*)
 
 
-Options[KerrGeoOrbitTripleResonant\[Beta]r]={PrecisionGoal->Automatic};
+Options[KerrGeoOrbitTripleResonantPX\[Beta]r]={PrecisionGoal->Automatic};
 
 
-KerrGeoOrbitTripleResonant\[Beta]r[a_?NumericQ, e_?NumericQ, {\[Beta]\[Theta]_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
+KerrGeoOrbitTripleResonantPX\[Beta]r[a_?NumericQ, e_?NumericQ, {\[Beta]\[Theta]_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
 Module[{pg,argpg,resonantEqnr\[Theta],resonantEqnr\[Phi],p0Test,p1Test,r\[Theta]ratio0,r\[Theta]ratio1,\[Phi]\[Theta]ratio},
 	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidXQ[x]||Not@ValidResIntQ[0,\[Beta]\[Theta],\[Beta]\[Phi]],Abort[]];
 	\[Phi]\[Theta]ratio=\[Beta]\[Phi]/\[Beta]\[Theta];
@@ -1076,10 +1030,10 @@ Module[{pg,argpg,resonantEqnr\[Theta],resonantEqnr\[Phi],p0Test,p1Test,r\[Theta]
 (*Given (a,e,\[Beta]r,\[Beta]\[Phi]) find (\[Beta]\[Theta]min, \[Beta]\[Theta]max)*)
 
 
-Options[KerrGeoOrbitTripleResonant\[Beta]\[Theta]]={PrecisionGoal->Automatic};
+Options[KerrGeoOrbitTripleResonantPX\[Beta]\[Theta]]={PrecisionGoal->Automatic};
 
 
-KerrGeoOrbitTripleResonant\[Beta]\[Theta][a_?NumericQ, e_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
+KerrGeoOrbitTripleResonantPX\[Beta]\[Theta][a_?NumericQ, e_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
 Module[{pg,argpg,resonantEqnr\[Theta],resonantEqnr\[Phi],p0Test,p1Test,r\[Theta]ratio0,r\[Theta]ratio1,r\[Phi]ratio},
 	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,0,\[Beta]\[Phi]],Abort[]];
 	r\[Phi]ratio=\[Beta]r/\[Beta]\[Phi];
@@ -1095,10 +1049,10 @@ Module[{pg,argpg,resonantEqnr\[Theta],resonantEqnr\[Phi],p0Test,p1Test,r\[Theta]
 (*Given (a,e,\[Beta]r,\[Beta]\[Theta]) find (\[Beta]\[Phi]min, \[Beta]\[Phi]max)*)
 
 
-Options[KerrGeoOrbitTripleResonant\[Beta]\[Phi]]={PrecisionGoal->Automatic};
+Options[KerrGeoOrbitTripleResonantPX\[Beta]\[Phi]]={PrecisionGoal->Automatic};
 
 
-KerrGeoOrbitTripleResonant\[Beta]\[Phi][a_?NumericQ, e_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Theta]_Integer}, opts:OptionsPattern[]]:=
+KerrGeoOrbitTripleResonantPX\[Beta]\[Phi][a_?NumericQ, e_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Theta]_Integer}, opts:OptionsPattern[]]:=
 Module[{pg,argpg,resonantEqnr\[Theta],resonantEqnr\[Phi],p0Test,p1Test,r\[Phi]ratio0,r\[Phi]ratio1,r\[Theta]ratio},
 	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Theta],0],Abort[]];
 	r\[Theta]ratio=\[Beta]r/\[Beta]\[Theta];
@@ -1131,9 +1085,9 @@ Module[{pg,argpg,resonantEqnr\[Theta],resonantEqnr\[Phi],pGuess,xGuess,pp,xx,r\[
 	p1r\[Phi]Test=KerrGeoOrbitRPhiResonantP[a, e, Sign[r\[Phi]ratio], {\[Beta]r, \[Beta]\[Phi]},opts];
 	checkSolution=(p0r\[Theta]Test-p0r\[Phi]Test)(p1r\[Theta]Test-p1r\[Phi]Test);
 	If[checkSolution>0,
-		rInts=KerrGeoOrbitTripleResonant\[Beta]r[a, e, {\[Beta]\[Theta], \[Beta]\[Phi]}, opts];
-		\[Theta]Ints=KerrGeoOrbitTripleResonant\[Beta]\[Theta][a, e, {\[Beta]r, \[Beta]\[Phi]}, opts];
-		\[Phi]Ints=KerrGeoOrbitTripleResonant\[Beta]\[Phi][a, e, {\[Beta]r, \[Beta]\[Theta]}, opts];
+		rInts=KerrGeoOrbitTripleResonantPX\[Beta]r[a, e, {\[Beta]\[Theta], \[Beta]\[Phi]}, opts];
+		\[Theta]Ints=KerrGeoOrbitTripleResonantPX\[Beta]\[Theta][a, e, {\[Beta]r, \[Beta]\[Phi]}, opts];
+		\[Phi]Ints=KerrGeoOrbitTripleResonantPX\[Beta]\[Phi][a, e, {\[Beta]r, \[Beta]\[Theta]}, opts];
 		Message[KerrGeoFindResonance::noTripleResonance,rInts[[1]],rInts[[2]],\[Theta]Ints[[1]],\[Theta]Ints[[2]],\[Phi]Ints[[1]],\[Phi]Ints[[2]]];
 		Abort[]];
 	

--- a/Kernel/SpecialOrbits.m
+++ b/Kernel/SpecialOrbits.m
@@ -8,12 +8,12 @@
 (*Define usage for public functions*)
 
 
-(* ::Section::Closed:: *)
+(* ::Section:: *)
 (*Create Package*)
 
 
 BeginPackage["KerrGeodesics`SpecialOrbits`",
-	{"KerrGeodesics`ConstantsOfMotion`"}];
+	{"KerrGeodesics`ConstantsOfMotion`", "KerrGeodesics`OrbitalFrequencies`"}];
 
 
 (* ::Subsection::Closed:: *)
@@ -37,7 +37,7 @@ KerrGeoScatterOrbitQ::usage = "KerrGeoScatterOrbitQ[a,p,e,x] tests if the orbita
 KerrGeoPlungeOrbitQ::usage = "KerrGeoPlungeOrbitQ[a,p,e,x] tests if the orbital parameters correspond to a plunge orbit."*)
 
 
-(* ::Subsection::Closed:: *)
+(* ::Subsection:: *)
 (*Error messages*)
 
 
@@ -45,9 +45,11 @@ KerrGeoFindResonance::noresonance = "Resonant orbits only occur for semi-latus r
 KerrGeoFindResonance::invalida = "Invalid black hole spin parameter. Choose 0 < a \[LessEqual] 1."
 KerrGeoFindResonance::invalide = "Invalid orbital eccentricity. Choose 0 \[LessEqual] e \[LessEqual] 1."
 KerrGeoFindResonance::invalidx = "Invalid orbital inclination. Choose 0 \[LessEqual] |x| \[LessEqual] 1."
-KerrGeoFindResonance::invalidratio = "Invalid resonant integers. Choose \[Beta]r > \[Beta]\[Theta]."
+KerrGeoFindResonance::invalidratio = "Invalid resonant integers. Choose \[Beta]r > \[Beta]\[Theta] > 0, \[Beta]r > \[Beta]\[Phi] > 0."
 KerrGeoFindResonance::assocErr = "Association should have 3 keys including both {a,x} and one of {p,e}"
 KerrGeoFindResonance::missing = "Resonaces involving the \[Phi] frequency are not yet implemented"
+KerrGeoFindResonance::prograde = "The solution is prograde: `1`"
+KerrGeoFindResonance::retrograde = "The solution is retrograde: `1`"
 
 
 (* ::Subsection::Closed:: *)
@@ -79,7 +81,7 @@ KerrGeoISCO[a_,x_/;x^2==1]:=Module[{M=1,Z1,Z2},
 ];
 
 
-(* ::Section:: *)
+(* ::Section::Closed:: *)
 (*Photon Sphere*)
 
 
@@ -134,7 +136,7 @@ This seems to be fine near the equatorial plane but might not be ideal for incli
 ]
 
 
-(* ::Section:: *)
+(* ::Section::Closed:: *)
 (*Innermost bound spherical orbits (IBSO)*)
 
 
@@ -176,7 +178,7 @@ KerrGeoIBSO[a1_?NumericQ,x1_?NumericQ]/;(Precision[{a1,x1}]!=\[Infinity])&&(-1<=
 p/.FindRoot[IBSOPoly/.{a->a1,x->x1},{p,KerrGeoIBSO[a1,0],KerrGeoIBSO[a1,-1]},WorkingPrecision->Max[MachinePrecision,prec-1]]];
 
 
-(* ::Section:: *)
+(* ::Section::Closed:: *)
 (*Separatrix*)
 
 
@@ -336,11 +338,11 @@ KerrGeoOrbitType[a_?NumericQ, p_?NumericQ, e_?NumericQ, x_?NumericQ]:=Module[{ou
 ]
 
 
-(* ::Section::Closed:: *)
+(* ::Section:: *)
 (*Resonances*)
 
 
-(* ::Subsection::Closed:: *)
+(* ::Subsection:: *)
 (*r\[Theta]-resonances*)
 
 
@@ -349,7 +351,7 @@ KerrGeoOrbitType[a_?NumericQ, p_?NumericQ, e_?NumericQ, x_?NumericQ]:=Module[{ou
 (*	- Root finding methods are based on those described in Sec.  VE*)
 
 
-(* ::Subsubsection::Closed:: *)
+(* ::Subsubsection:: *)
 (*Testing functions*)
 
 
@@ -372,12 +374,12 @@ ValidXQ[x_]:=Module[{xFlag=True},
 
 
 ValidResIntQ[\[Beta]r_,\[Beta]th_]:=Module[{resFlag},
-	If[\[Beta]r>\[Beta]th, Message[KerrGeoFindResonance::invalidratio]; resFlag=False];
+	If[!(\[Beta]th>\[Beta]r>0), Message[KerrGeoFindResonance::invalidratio]; resFlag=False];
 	resFlag
 ];
 
 
-(* ::Subsubsection::Closed:: *)
+(* ::Subsubsection:: *)
 (*Useful functions for root-finding*)
 
 
@@ -444,13 +446,15 @@ Rf[0,alpha_,beta_]:=beta^(-1/2)EllipticK[1-alpha/beta];
 (*	Root finding methods are based on those described in Sec.  VE*)
 
 
-Options[KerrGeoOrbitRThetaResonantP]={PrecisionGoal->Automatic};
+Options[KerrGeoOrbitRThetaResonantP]={PrecisionGoal->Automatic, Rotation->"Both"};
 
 
 KerrGeoOrbitRThetaResonantP[a_?NumericQ, e_?NumericQ, x_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Theta]_Integer}, opts:OptionsPattern[]]:=
 Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest},
 	(*See if the user specified some precision goal *)
 	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Theta]],Abort[]];
+	If[OptionValue[Rotation]=="Prograde" & x<0, Abort[]];
+	If[OptionValue[Rotation]=="Retrograde" & x>0, Abort[]];
 	
 	pg=OptionValue[PrecisionGoal];
 	ratio=\[Beta]r/\[Beta]\[Theta];
@@ -480,22 +484,24 @@ Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest},
 (*Given (a,p,x) and Subscript[\[CapitalOmega], r]/Subscript[\[CapitalOmega], \[Theta]]= Subscript[\[Beta], r]/Subscript[\[Beta], \[Theta]] find e*)
 
 
-Options[KerrGeoOrbitRThetaResonantE]={PrecisionGoal->Automatic};
+Options[KerrGeoOrbitRThetaResonantE]={PrecisionGoal->Automatic, Rotation->"Both"};
 
 
 KerrGeoOrbitRThetaResonantE[a_?NumericQ, p_?NumericQ, x_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Theta]_Integer}, opts:OptionsPattern[]]:=
 Module[{pg,argpg,resonantEqn,e0Test,e1Test,eGuess,ee,ratio},
 	(*See if the user specified some precision goal *)
 	If[Not@ValidAQ[a]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Theta]],Abort[]];
+	If[OptionValue[Rotation]=="Prograde" & x<0, Abort[]];
+	If[OptionValue[Rotation]=="Retrograde" & x>0, Abort[]];
 	
 	pg=OptionValue[PrecisionGoal];
 	ratio=\[Beta]r/\[Beta]\[Theta];
 	
 	(* Test to see if there is an eccentricity that will lead to a bound orbital resonance 
 	 based on the provided values of a, p, x *)
-	e0Test=KerrGeoOrbitRThetaResonantP[a,0,x,{\[Beta]r,\[Beta]\[Theta]},opts];
-	e1Test=KerrGeoOrbitRThetaResonantP[a,1,x,{\[Beta]r,\[Beta]\[Theta]},opts];
-	If[p<e0Test || p> e1Test, Message[KerrGeoFindResonance::noresonance, e0Test, e1Test ]; Abort[];];
+	e0Test=KerrGeoOrbitRThetaResonantP[a,0,x,{\[Beta]r,\[Beta]\[Theta]}, opts];
+	e1Test=KerrGeoOrbitRThetaResonantP[a,1,x,{\[Beta]r,\[Beta]\[Theta]}, opts];
+	If[p<e0Test||e1Test<p, Message[KerrGeoFindResonance::noresonance, e0Test, e1Test]; Abort[];];
 	If[p==e0Test,Return[0]];
 	If[p==e1Test,Return[1]];
 	eGuess=(p-e0Test)/(e1Test-e0Test);
@@ -523,25 +529,27 @@ Module[{pg,argpg,resonantEqn,e0Test,e1Test,eGuess,ee,ratio},
 (*Given (a,p,e) and Subscript[\[CapitalOmega], r]/Subscript[\[CapitalOmega], \[Theta]]= Subscript[\[Beta], r]/Subscript[\[Beta], \[Theta]] find x*)
 
 
-Options[KerrGeoOrbitRThetaResonantX]={PrecisionGoal->Automatic};
+Options[KerrGeoOrbitRThetaResonantX]={PrecisionGoal->Automatic, Rotation->"Both"};
 
 
 KerrGeoOrbitRThetaResonantX[a_?NumericQ, p_?NumericQ, e_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Theta]_Integer}, opts:OptionsPattern[]]:=
-Module[{pg,argpg,resonantEqn,x0Test,x1Test,xGuess,xx,ratio},
+Module[{pg,rtt,argpg,resonantEqn,x1Test1,x1Test2,xGuess,xx,xxx,ratio},
 	(*See if the user specified some precision goal *)
 	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Theta]],Abort[]];
 	
+	rtt=OptionValue[Rotation];
 	pg=OptionValue[PrecisionGoal];
 	ratio=\[Beta]r/\[Beta]\[Theta];
 	
-	(* Test to see if there is an eccentricity that will lead to a bound orbital resonance 
-	 based on the provided values of a, p, x *)
-	x0Test=KerrGeoOrbitRThetaResonantP[a,e,-1,{\[Beta]r,\[Beta]\[Theta]},opts];
-	x1Test=KerrGeoOrbitRThetaResonantP[a,e,1,{\[Beta]r,\[Beta]\[Theta]},opts];
-	If[p>x0Test || p< x1Test, Message[KerrGeoFindResonance::noresonance, x1Test, x0Test ]; Abort[];];
-	If[p==x0Test,Return[-1]];
-	If[p==x1Test,Return[1]];
-	xGuess=-(2p-(x0Test+x1Test))/(x0Test-x1Test);
+	(* Test to see if there is an inclination angle that will lead to a bound orbital resonance 
+	 based on the provided values of a, p, e *)
+	x1Test1=KerrGeoOrbitRThetaResonantP[a,e,1,{\[Beta]r,\[Beta]\[Theta]},PrecisionGoal->pg];
+	x1Test2=KerrGeoOrbitRThetaResonantP[a,e,-1,{\[Beta]r,\[Beta]\[Theta]},PrecisionGoal->pg];
+	
+	If[p>x1Test2 || p< x1Test1, Message[KerrGeoFindResonance::noresonance, x1Test1, x1Test2]; Abort[];];
+	If[p==x1Test1,Return[1]];
+	If[p==x1Test2,Return[-1]];
+	xGuess=-(2p-(x1Test2+x1Test1))/(x1Test2-x1Test1);
 
 	(* Resonant condition defined by the equation below *)
 	resonantEqn[x_?NumericQ]:=Sqrt[y1y2[a,p,e,x]]Rf[0,1+del2y2[a,p,e,x],1-del2y2[a,p,e,x]]/Rf[0,1+del1y1[a,p,e,x],1-del1y1[a,p,e,x]]-ratio;
@@ -555,26 +563,420 @@ Module[{pg,argpg,resonantEqn,x0Test,x1Test,xGuess,xx,ratio},
 	If[pg==Infinity,pg=$MachinePrecision];
 
 	If[pg==$MachinePrecision,
-		Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess}]],
-		Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess},PrecisionGoal->pg,WorkingPrecision->0.95argpg]],
-		Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess},PrecisionGoal->pg,WorkingPrecision->0.95argpg]]
-	]
+		xxx=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess}]],
+		xxx=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess},PrecisionGoal->pg,WorkingPrecision->0.95argpg]],
+		xxx=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess},PrecisionGoal->pg,WorkingPrecision->0.95argpg]]
+	];
+	If[(rtt=="Prograde"&&xxx>0)||(rtt=="Retrograde"&&xxx<0)||rtt=="Both", Return[xxx]];
+	If[rtt=="Prograde"&&xxx<0, Message[KerrGeoFindResonance::retrograde, xxx]; Abort[]];
+	If[rtt=="Retrograde"&&xxx>0, Message[KerrGeoFindResonance::prograde, xxx]; Abort[]];
 ];
 
 
-(* ::Subsection::Closed:: *)
+(* ::Subsection:: *)
+(*r\[Phi]-resonances*)
+
+
+(* ::Subsubsection::Closed:: *)
+(*Testing functions*)
+
+
+(* ::Text:: *)
+(*Same as those of r\[Theta]-resonance*)
+
+
+(* ::Subsubsection::Closed:: *)
+(*Useful functions for root-finding*)
+
+
+r\[Phi]Ratio[a_, p_, e_, x_/;x!=0] := Abs[KerrGeoFrequencies[a, p, e, x, Time->"Mino"]["\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(r\)]\)"]/KerrGeoFrequencies[a, p, e, x, Time->"Mino"]["\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Phi]\)]\)"]]
+
+r\[Phi]Ratio[a_, p_, e_/;e!=1, x_/;x==0]:=
+Module[{S, P, r1, r2, r3, r4, EnSquared, Q, kr, k\[Theta], factor1, factor2, rPlus, rMinus, hPlus, hMinus, hr, BrPlus, BrMinus, Br, r\[Theta]Ratio},
+	(* S=r3+r4, P=r3*r4 *)
+	P = (a^2(a^4(-1+e^2)2+p^4+2a^2p(-2+p+e^2(2+p))))/(a^4(-1+e^2)^2+2a^2(1+e^2)p^2+(-4+p)p^3);
+	S = (2(a^2(-1+e^2)+p^2)^2)/(a^4(-1+e^2)^2+2a^2(1+e^2)p^2+(-4+p)p^3);
+	EnSquared = 1+2(-1+e^2)/(2p+S-e^2S);
+    Q = 2p^2P/(a^2(2p+S-e^2S));
+    r1 = p/(1-e);
+    r2 = p/(1+e);
+    r3 = (S+Sqrt[S^2-4P])/2;
+    r4 = (S-Sqrt[S^2-4P])/2;
+    kr = (r1-r2)/(r1-r3)(r3-r4)/(r2-r4);
+    k\[Theta] = (1-EnSquared)a^2/Q;
+    factor1 = Sqrt[(r1-r3)(r2-r4)2(1-e^2)a^2/(2p^2P)];
+    r\[Theta]Ratio = factor1 EllipticK[k\[Theta]]/EllipticK[kr];
+    
+    rPlus = 1+Sqrt[1-a^2];
+    rMinus = 1-Sqrt[1-a^2];
+    hr = (r1-r2)/(r1-r3);
+    hPlus = hr (r3-rPlus)/(r2-rPlus);
+    hMinus = hr (r3-rMinus)/(r2-rMinus);
+    factor2 = 2a/(Pi(rPlus-rMinus)Sqrt[(1-EnSquared)(r1-r3)(r2-r4)])2Sqrt[EnSquared];
+    BrPlus = rPlus/(r3-rPlus)(EllipticK[kr]-(r2-r3)/(r2-rPlus)EllipticPi[hPlus, kr]);
+    BrMinus = rMinus/(r3-rMinus)(EllipticK[kr]-(r2-r3)/(r2-rMinus)EllipticPi[hPlus, kr]);
+    Br = factor2(BrPlus-BrMinus);
+    (* {prograde, retrograde} *)
+    {Abs[1/(1/r\[Theta]Ratio+Br)],Abs[1/(-1/r\[Theta]Ratio+Br)]}
+]
+
+r\[Phi]Ratio[a_, p_, e_/;e==1, x_/;x==0]:=
+Module[{S, P, r1, r2, r3, r4, EnSquared, Q, kr, k\[Theta], factor1, factor2, rPlus, rMinus, hPlus, hMinus, hr, BrPlus, BrMinus, Br, r\[Theta]Ratio},
+	(* S=r3+r4, P=r3*r4 *)
+	P = (a^2 (4 a^2 p^2+p^4))/(4 a^2 p^2+(-4+p) p^3);
+	S = (2 p^4)/(4 a^2 p^2 + (-4 + p) p^3);
+	EnSquared = 1;
+    Q = 2p^2P/(a^2 2p);
+    (* r1=p/(1-e) diverges *)
+    r2 = p/2;
+    r3 = (S+Sqrt[S^2-4P])/2;
+    r4 = (S-Sqrt[S^2-4P])/2;
+    kr = (r3-r4)/(r2-r4);
+    k\[Theta] = (1-EnSquared)a^2/Q;
+    factor1 = Sqrt[(2p)(r2-r4)2a^2/(2p^2P)];
+    r\[Theta]Ratio = factor1 EllipticK[k\[Theta]]/EllipticK[kr];
+    
+    rPlus = 1+Sqrt[1-a^2];
+    rMinus = 1-Sqrt[1-a^2];
+    hPlus = (r3-rPlus)/(r2-rPlus);
+    hMinus = (r3-rMinus)/(r2-rMinus);
+    factor2 = 2a/(Pi(rPlus-rMinus)Sqrt[2(r2-r4)])2Sqrt[EnSquared];
+    BrPlus = rPlus/(r3-rPlus)(EllipticK[kr]-(r2-r3)/(r2-rPlus)EllipticPi[hPlus, kr]);
+    BrMinus = rMinus/(r3-rMinus)(EllipticK[kr]-(r2-r3)/(r2-rMinus)EllipticPi[hPlus, kr]);
+    Br = factor2(BrPlus-BrMinus);
+    (* {prograde, retrograde} *)
+    {Abs[1/(1/r\[Theta]Ratio+Br)],Abs[1/(-1/r\[Theta]Ratio+Br)]}
+]
+
+
+(* ::Subsubsection::Closed:: *)
+(*Given (a,e,x) and Subscript[\[CapitalOmega], r]/Subscript[\[CapitalOmega], \[Phi]]= Subscript[\[Beta], r]/Subscript[\[Beta], \[Phi]] find p*)
+
+
+Options[KerrGeoOrbitRPhiResonantP]={PrecisionGoal->Automatic, Rotation->"Both"};
+
+
+KerrGeoOrbitRPhiResonantP[a_?NumericQ, e_?NumericQ, x_?NumericQ/;x!=0, {\[Beta]r_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
+Module[{pg,rtt,ratio,argpg,resonantEqn,pStar,pp,pgTest},
+	(*See if the user specified some precision goal *)
+	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Phi]],Abort[]];
+	
+	rtt=OptionValue[Rotation];
+	If[rtt=="Prograde" & x<0, Abort[]];
+	If[rtt=="Retrograde" & x>0, Abort[]];
+	
+	pg=OptionValue[PrecisionGoal];
+	ratio=\[Beta]r/\[Beta]\[Phi];
+	(* pStar provides an initial guess for p. Note that p = pStar for e = 0 and a = 0*)
+	pStar=6/(1-ratio^2);
+
+	(* Resonant condition defined by the equation below *)
+	resonantEqn[p_?NumericQ]:=r\[Phi]Ratio[a, p, e, x]-ratio;
+	
+	(* Working precision of the root-finding method is based on the precision specified
+	 by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
+	 is the default precision if not other precision specifications are made. *)
+	argpg=Precision[{resonantEqn[pStar],a,e,x,ratio}];
+	If[argpg==$MachinePrecision,pg=argpg];
+	If[(Not@NumericQ[pg]||pg>argpg),pg=argpg];
+	If[pg==Infinity,pg=$MachinePrecision];
+	
+	If[pg==$MachinePrecision,
+		Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar}]],
+		Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar},PrecisionGoal->pg,WorkingPrecision->pg]],
+		Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar},PrecisionGoal->pg,WorkingPrecision->pg]]
+	]
+];
+
+KerrGeoOrbitRPhiResonantP[a_?NumericQ, e_?NumericQ, x_?NumericQ/;x==0, {\[Beta]r_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
+Module[{pg,rtt,ratio,argpg,resonantEqn,pStar,pp,pp1,pp2,pgTest},
+	(*See if the user specified some precision goal *)
+	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Phi]],Abort[]];
+	
+	rtt=OptionValue[Rotation];
+	pg=OptionValue[PrecisionGoal];
+	ratio=\[Beta]r/\[Beta]\[Phi];
+	(* pStar provides an initial guess for p. Note that p = pStar for e = 0 and a = 0*)
+	pStar=6/(1-ratio^2);
+	If[rtt=="Prograde"||rtt=="Both",
+		(* Resonant condition defined by the equation below *)
+		resonantEqn[p_?NumericQ]:=r\[Phi]Ratio[a, p, e, 0][[1]]-ratio;
+		(* Working precision of the root-finding method is based on the precision specified
+			by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
+			is the default precision if not other precision specifications are made. *)
+		argpg=Precision[{resonantEqn[pStar],a,e,x,ratio}];
+		If[argpg==$MachinePrecision,pg=argpg];
+		If[(Not@NumericQ[pg]||pg>argpg),pg=argpg];
+		If[pg==Infinity,pg=$MachinePrecision];
+		If[pg==$MachinePrecision,
+				pp1=Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar}]],
+				pp1=Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar},PrecisionGoal->pg,WorkingPrecision->pg]],
+				pp1=Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar},PrecisionGoal->pg,WorkingPrecision->pg]]
+		];
+	];
+	If[rtt=="Retrograde"||rtt=="Both",
+		(* Resonant condition defined by the equation below *)
+		resonantEqn[p_?NumericQ]:=r\[Phi]Ratio[a, p, e, 0][[2]]-ratio;
+		(* Working precision of the root-finding method is based on the precision specified
+		by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
+		is the default precision if not other precision specifications are made. *)
+		argpg=Precision[{resonantEqn[pStar],a,e,x,ratio}];
+		If[argpg==$MachinePrecision,pg=argpg];
+		If[(Not@NumericQ[pg]||pg>argpg),pg=argpg];
+		If[pg==Infinity,pg=$MachinePrecision];
+		If[pg==$MachinePrecision,
+				pp2=Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar}]],
+				pp2=Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar},PrecisionGoal->pg,WorkingPrecision->pg]],
+				pp2=Re[pp/.FindRoot[resonantEqn[pp],{pp,pStar},PrecisionGoal->pg,WorkingPrecision->pg]]
+		];
+	];
+	Switch[rtt,"Prograde", Return[pp1],"Retrograde", Return[pp2],"Both", Return[{pp1, pp2}]];
+];
+
+
+(* ::Subsubsection::Closed:: *)
+(*Given (a,p,x) and Subscript[\[CapitalOmega], r]/Subscript[\[CapitalOmega], \[Phi]]= Subscript[\[Beta], r]/Subscript[\[Beta], \[Phi]] find e*)
+
+
+Options[KerrGeoOrbitRPhiResonantE]={PrecisionGoal->Automatic, Rotation->"Both"};
+
+
+KerrGeoOrbitRPhiResonantE[a_?NumericQ, p_?NumericQ, x_?NumericQ/;x!=0, {\[Beta]r_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
+Module[{pg,rtt,argpg,resonantEqn,e0Test,e1Test,eGuess,ee,ratio},
+	(*See if the user specified some precision goal *)
+	If[Not@ValidAQ[a]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Phi]],Abort[]];
+	
+	pg=OptionValue[PrecisionGoal];
+	rtt=OptionValue[Rotation];
+	If[rtt=="Prograde" & x<0, Abort[]];
+	If[rtt=="Retrograde" & x>0, Abort[]];
+	
+	ratio=\[Beta]r/\[Beta]\[Phi];
+	
+	(* Test to see if there is an eccentricity that will lead to a bound orbital resonance 
+	 based on the provided values of a, p, x *)
+	e0Test=KerrGeoOrbitRPhiResonantP[a,0,x,{\[Beta]r,\[Beta]\[Phi]},opts];
+	e1Test=KerrGeoOrbitRPhiResonantP[a,1,x,{\[Beta]r,\[Beta]\[Phi]},opts];
+	If[p<e0Test||e1Test<p, Message[KerrGeoFindResonance::noresonance, e0Test, e1Test]; Abort[];];
+	If[p==e0Test,Return[0]];
+	If[p==e1Test,Return[1]];
+	eGuess=(p-e0Test)/(e1Test-e0Test);
+
+	(* Resonant condition defined by the equation below *)
+	resonantEqn[e_?NumericQ]:= r\[Phi]Ratio[a, p, e, x]-ratio;
+	
+	(* Working precision of the root-finding method is based on the precision specified
+	 by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
+	 is the default precision if not other precision specifications are made. *)
+	argpg=Precision[{resonantEqn[eGuess],a,p,x,ratio}];
+	If[argpg==$MachinePrecision,pg=argpg];
+	If[(Not@NumericQ[pg]||pg>argpg),pg=argpg];
+	If[pg==Infinity,pg=$MachinePrecision];
+
+	If[pg==$MachinePrecision,
+		Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess}]],
+		Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess},PrecisionGoal->pg,WorkingPrecision->pg]],
+		Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess},PrecisionGoal->pg,WorkingPrecision->pg]]
+	]
+];
+
+KerrGeoOrbitRPhiResonantE[a_?NumericQ, p_?NumericQ, x_?NumericQ/;x==0, {\[Beta]r_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
+Module[{pg,rtt,argpg,resonantEqn,e0Test,e1Test,eGuess,ee,ee1,ee2,ratio},
+	(*See if the user specified some precision goal *)
+	If[Not@ValidAQ[a]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Phi]],Abort[]];
+	
+	pg=OptionValue[PrecisionGoal];
+	rtt=OptionValue[Rotation];
+	
+	ratio=\[Beta]r/\[Beta]\[Phi];
+	e0Test=KerrGeoOrbitRPhiResonantP[a,0,x,{\[Beta]r,\[Beta]\[Phi]},opts];
+	e1Test=KerrGeoOrbitRPhiResonantP[a,1,x,{\[Beta]r,\[Beta]\[Phi]},opts];
+	
+	If[rtt=="Prograde",
+		If[p<e0Test||e1Test<p, Message[KerrGeoFindResonance::noresonance, e0Test, e1Test]; Abort[];];
+		If[p==e0Test,Return[0]];
+		If[p==e1Test,Return[1]];
+		eGuess=(p-e0Test)/(e1Test-e0Test);
+	
+		(* Resonant condition defined by the equation below *)
+		resonantEqn[e_?NumericQ]:= r\[Phi]Ratio[a, p, e, x][[1]]-ratio;
+		
+		(* Working precision of the root-finding method is based on the precision specified
+		 by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
+		 is the default precision if not other precision specifications are made. *)
+		argpg=Precision[{resonantEqn[eGuess],a,p,x,ratio}];
+		If[argpg==$MachinePrecision,pg=argpg];
+		If[(Not@NumericQ[pg]||pg>argpg),pg=argpg];
+		If[pg==Infinity,pg=$MachinePrecision];
+		If[pg==$MachinePrecision,
+			ee1=Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess}]],
+			ee1=Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess},PrecisionGoal->pg,WorkingPrecision->pg]],
+			ee1=Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess},PrecisionGoal->pg,WorkingPrecision->pg]]
+		];
+		Return[ee1];
+	];
+	
+	If[rtt=="Retrograde",
+		If[p<e0Test||e1Test<p, Message[KerrGeoFindResonance::noresonance, e0Test, e1Test]; Abort[];];
+		If[p==e0Test,Return[0]];
+		If[p==e1Test,Return[1]];
+		eGuess=(p-e0Test)/(e1Test-e0Test);
+	
+		(* Resonant condition defined by the equation below *)
+		resonantEqn[e_?NumericQ]:= r\[Phi]Ratio[a, p, e, x][[2]]-ratio;
+		
+		(* Working precision of the root-finding method is based on the precision specified
+		 by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
+		 is the default precision if not other precision specifications are made. *)
+		argpg=Precision[{resonantEqn[eGuess],a,p,x,ratio}];
+		If[argpg==$MachinePrecision,pg=argpg];
+		If[(Not@NumericQ[pg]||pg>argpg),pg=argpg];
+		If[pg==Infinity,pg=$MachinePrecision];
+		If[pg==$MachinePrecision,
+			ee2=Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess}]],
+			ee2=Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess},PrecisionGoal->pg,WorkingPrecision->pg]],
+			ee2=Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess},PrecisionGoal->pg,WorkingPrecision->pg]]
+		];
+		Return[ee2];
+	];
+	
+	If[rtt=="Both",
+		If[p<e0Test[[2]]||e1Test[[2]]<p<e0Test[[1]]|| e1Test[[1]]<p,
+			Message[KerrGeoFindResonance::noresonance, e0Test[[1]], e1Test[[1]]];
+			Message[KerrGeoFindResonance::noresonance, e0Test[[2]], e1Test[[2]]];
+			Abort[]
+		];
+		If[e0Test[[1]]<p<e1Test[[1]],
+			eGuess=(p-e0Test[[1]])/(e1Test[[1]]-e0Test[[1]]);
+			resonantEqn[e_?NumericQ]:= r\[Phi]Ratio[a, p, e, x][[1]]-ratio;
+			argpg=Precision[{resonantEqn[eGuess],a,p,x,ratio}];
+			If[argpg==$MachinePrecision,pg=argpg];
+			If[(Not@NumericQ[pg]||pg>argpg),pg=argpg];
+			If[pg==Infinity,pg=$MachinePrecision];
+			If[pg==$MachinePrecision,
+				ee1=Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess}]],
+				ee1=Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess},PrecisionGoal->pg,WorkingPrecision->pg]],
+				ee1=Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess},PrecisionGoal->pg,WorkingPrecision->pg]]
+			];
+			Return[ee1];
+		];
+		If[e0Test[[2]]<p<e1Test[[2]],
+			eGuess=(p-e0Test[[2]])/(e1Test[[2]]-e0Test[[2]]);
+			resonantEqn[e_?NumericQ]:= r\[Phi]Ratio[a, p, e, x][[2]]-ratio;
+			argpg=Precision[{resonantEqn[eGuess],a,p,x,ratio}];
+			If[argpg==$MachinePrecision,pg=argpg];
+			If[(Not@NumericQ[pg]||pg>argpg),pg=argpg];
+			If[pg==Infinity,pg=$MachinePrecision];
+			If[pg==$MachinePrecision,
+				ee2=Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess}]],
+				ee2=Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess},PrecisionGoal->pg,WorkingPrecision->pg]],
+				ee2=Re[ee/.FindRoot[resonantEqn[ee],{ee,eGuess},PrecisionGoal->pg,WorkingPrecision->pg]]
+			];
+			Return[ee2];	
+		];
+	];
+];
+
+
+(* ::Subsubsection:: *)
+(*Given (a,p,e) and Subscript[\[CapitalOmega], r]/Subscript[\[CapitalOmega], \[Phi]]= Subscript[\[Beta], r]/Subscript[\[Beta], \[Phi]] find x*)
+
+
+Options[KerrGeoOrbitRPhiResonantX]={PrecisionGoal->Automatic, Rotation->"Both"};
+
+
+KerrGeoOrbitRPhiResonantX[a_?NumericQ, p_?NumericQ, e_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
+Module[{pg,rtt,argpg,resonantEqn,x0Test1,x0Test2,x1Test1,x1Test2,xGuess,xx1,xx2,xx,ratio},
+	(*See if the user specified some precision goal *)
+	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Phi]],Abort[]];
+	
+	rtt=OptionValue[Rotation];
+	pg=OptionValue[PrecisionGoal];
+	ratio=\[Beta]r/\[Beta]\[Phi];
+	
+	(* Test to see if there is an eccentricity that will lead to a bound orbital resonance 
+	 based on the provided values of a, p, x *)
+	{x0Test1,x0Test2}=KerrGeoOrbitRPhiResonantP[a,e,0,{\[Beta]r,\[Beta]\[Phi]}, PrecisionGoal->pg];
+	x1Test1=KerrGeoOrbitRPhiResonantP[a,e,1,{\[Beta]r,\[Beta]\[Phi]}, PrecisionGoal->pg];
+	x1Test2=KerrGeoOrbitRPhiResonantP[a,e,-1,{\[Beta]r,\[Beta]\[Phi]}, PrecisionGoal->pg];
+	If[p<x1Test1||x1Test2<p, Message[KerrGeoFindResonance::noresonance, x1Test1, x1Test2]; Abort[];];
+	If[x1Test1<p<x0Test2&&rtt=="Retrograde", Message[KerrGeoFindResonance::noresonance, x0Test2, x1Test2]; Abort[];];
+	If[x0Test1<p<x1Test2&&rtt=="Prograde", Message[KerrGeoFindResonance::noresonance, x1Test1, x0Test1]; Abort[];];
+	If[p==x1Test1,Return[1]];
+	If[p==x1Test2,Return[-1]];
+	If[p==x0Test1||p==x0Test2,Return[0]];
+	(* Resonant condition defined by the equation below *)
+	resonantEqn[x_?NumericQ]:=r\[Phi]Ratio[a, p, e, x]-ratio;
+	
+	If[x1Test1<p<x0Test1&&(rtt=="Prograde"||rtt=="Both"),
+		xGuess = (p-x0Test1)/(x1Test1-x0Test1);
+		(* Working precision of the root-finding method is based on the precision specified
+		 by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
+		 is the default precision if not other precision specifications are made. *)
+		argpg=Precision[{resonantEqn[xGuess],a,p,e,ratio}];
+		If[argpg==$MachinePrecision,pg=0.9argpg];
+		If[(Not@NumericQ[pg]||pg>argpg),pg=0.9argpg];
+		If[pg==Infinity,pg=$MachinePrecision];
+		If[pg==$MachinePrecision,
+			xx1=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess}]],
+			xx1=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess},PrecisionGoal->pg,WorkingPrecision->0.95argpg]],
+			xx1=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess},PrecisionGoal->pg,WorkingPrecision->0.95argpg]]
+		]
+	];
+	If[x0Test2<p<x1Test2&&(rtt=="Retrograde"||rtt=="Both"),
+		xGuess = -(p-x0Test2)/(x1Test2-x0Test2);
+		(* Working precision of the root-finding method is based on the precision specified
+		 by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
+		 is the default precision if not other precision specifications are made. *)
+		argpg=Precision[{resonantEqn[xGuess],a,p,e,ratio}];
+		If[argpg==$MachinePrecision,pg=0.9argpg];
+		If[(Not@NumericQ[pg]||pg>argpg),pg=0.9argpg];
+		If[pg==Infinity,pg=$MachinePrecision];
+		If[pg==$MachinePrecision,
+			xx2=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess}]],
+			xx2=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess},PrecisionGoal->pg,WorkingPrecision->0.95argpg]],
+			xx2=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess},PrecisionGoal->pg,WorkingPrecision->0.95argpg]]
+		]
+	];
+	Switch[rtt,
+		"Prograde", Return[xx1],
+		"Retrograde", Return[xx2],
+		"Both", 
+			If[x1Test1<p<x0Test2, Return[xx1]];
+			If[x0Test2<p<x0Test1, Return[{xx1, xx2}]];
+			If[x0Test1<p<x1Test2, Return[xx2]];
+	];
+];
+
+
+(* ::Subsection:: *)
 (*Generic resonance interface*)
 
 
-KerrGeoFindResonance[assoc_Association,{\[Beta]r_Integer, \[Beta]\[Theta]_Integer, \[Beta]\[Phi]_Integer}]:= Module[{},Message[KerrGeoFindResonance::missing]; Return[$Failed]];
+Options[KerrGeoFindResonance]={PrecisionGoal->Automatic, Rotation->"Both"};
 
-KerrGeoFindResonance[assoc_Association,{\[Beta]r_Integer, \[Beta]\[Theta]_Integer, 0}]:=Block[{},
+
+KerrGeoFindResonance[assoc_Association,{\[Beta]r_Integer, \[Beta]\[Theta]_Integer, \[Beta]\[Phi]_Integer},opts:OptionsPattern[]]:= Module[{},Message[KerrGeoFindResonance::missing]; Return[$Failed]];
+
+KerrGeoFindResonance[assoc_Association,{\[Beta]r_Integer, \[Beta]\[Theta]_Integer, 0},opts:OptionsPattern[]]:=Block[{},
 	If[ContainsExactly[Keys[assoc],{"a","p","x"}],
-		"e"->KerrGeoOrbitRThetaResonantE["a"/.assoc, "p"/.assoc, "x"/.assoc, {\[Beta]r, \[Beta]\[Theta]}],
+		"e"->KerrGeoOrbitRThetaResonantE["a"/.assoc, "p"/.assoc, "x"/.assoc, {\[Beta]r, \[Beta]\[Theta]}, opts],
 		If[ContainsExactly[Keys[assoc],{"a","e","x"}],
-			"p"->KerrGeoOrbitRThetaResonantP["a"/.assoc, "e"/.assoc, "x"/.assoc, {\[Beta]r, \[Beta]\[Theta]}],
+			"p"->KerrGeoOrbitRThetaResonantP["a"/.assoc, "e"/.assoc, "x"/.assoc, {\[Beta]r, \[Beta]\[Theta]}, opts],
 			If[ContainsExactly[Keys[assoc],{"a","p","e"}],
-				"x"->KerrGeoOrbitRThetaResonantX["a"/.assoc, "p"/.assoc, "e"/.assoc, {\[Beta]r, \[Beta]\[Theta]}],
+				"x"->KerrGeoOrbitRThetaResonantX["a"/.assoc, "p"/.assoc, "e"/.assoc, {\[Beta]r, \[Beta]\[Theta]}, opts],
+				Message[KerrGeoFindResonance::assocErr]
+			]
+		]
+	]
+]
+KerrGeoFindResonance[assoc_Association,{\[Beta]r_Integer, 0, \[Beta]\[Phi]_Integer},opts:OptionsPattern[]]:=Block[{},
+	If[ContainsExactly[Keys[assoc],{"a","p","x"}],
+		"e"->KerrGeoOrbitRPhiResonantE["a"/.assoc, "p"/.assoc, "x"/.assoc, {\[Beta]r, \[Beta]\[Phi]}, opts],
+		If[ContainsExactly[Keys[assoc],{"a","e","x"}],
+			"p"->KerrGeoOrbitRPhiResonantP["a"/.assoc, "e"/.assoc, "x"/.assoc, {\[Beta]r, \[Beta]\[Phi]}, opts],
+			If[ContainsExactly[Keys[assoc],{"a","p","e"}],
+				"x"->KerrGeoOrbitRPhiResonantX["a"/.assoc, "p"/.assoc, "e"/.assoc, {\[Beta]r, \[Beta]\[Phi]}, opts],
 				Message[KerrGeoFindResonance::assocErr]
 			]
 		]

--- a/Kernel/SpecialOrbits.m
+++ b/Kernel/SpecialOrbits.m
@@ -8,7 +8,7 @@
 (*Define usage for public functions*)
 
 
-(* ::Section:: *)
+(* ::Section::Closed:: *)
 (*Create Package*)
 
 
@@ -37,22 +37,23 @@ KerrGeoScatterOrbitQ::usage = "KerrGeoScatterOrbitQ[a,p,e,x] tests if the orbita
 KerrGeoPlungeOrbitQ::usage = "KerrGeoPlungeOrbitQ[a,p,e,x] tests if the orbital parameters correspond to a plunge orbit."*)
 
 
-(* ::Subsection:: *)
+(* ::Subsection::Closed:: *)
 (*Error messages*)
 
 
 KerrGeoFindResonance::noresonance = "Resonant orbits only occur for semi-latus rectum in range `1` \[LessEqual] p \[LessEqual] `2`"
 KerrGeoFindResonance::noTripleResonance = "No triple resonance; try `1` \[LessEqual] r-integer \[LessEqual] `2`, `3` \[LessEqual] \[Theta]-integer \[LessEqual] `4` or `5` \[LessEqual] \[Phi]-integer \[LessEqual] `6`"
+KerrGeoFindResonance::exceedBoundRatio = "No prograde (retrograde) resonace whose \[Phi]-\[Theta] ratio greater (lesser) than `1`"
 KerrGeoFindResonance::invalida = "Invalid black hole spin parameter. Choose 0 < a \[LessEqual] 1."
 KerrGeoFindResonance::invalide = "Invalid orbital eccentricity. Choose 0 \[LessEqual] e \[LessEqual] 1."
 KerrGeoFindResonance::invalidx = "Invalid orbital inclination. Choose 0 \[LessEqual] |x| \[LessEqual] 1."
 KerrGeoFindResonance::invalidRatio = "Invalid resonant integers. Choose |\[Beta]r| > |\[Beta]\[Theta]|, |\[Beta]r| > |\[Beta]\[Phi]| and \[Beta]\[Theta]*\[Beta]\[Phi] > 0."
 KerrGeoFindResonance::assocErr = "Association should have 3 keys including both a and two of {p, e, x}"
-KerrGeoFindResonance::assocErrTriple = "Only support association {a, e} for input"
+KerrGeoFindResonance::assocErrTriple = "Only support association {a, e} or {a, x} for input"
 KerrGeoFindResonance::missing = "Resonaces involving the \[Phi] frequency are not yet implemented"
 KerrGeoFindResonance::invalidPrograde = "Invalid prograde resonant integers. Choose \[Beta]r/\[Beta]\[Phi] > 0, \[Beta]r/\[Beta]\[Phi] > 0 and \[Beta]\[Theta] < \[Beta]\[Phi]"
 KerrGeoFindResonance::invalidRetrograde = "Invalid retrograde resonant integers. Choose \[Beta]r/\[Beta]\[Phi] < 0, \[Beta]r/\[Beta]\[Phi] < 0 and \[Beta]\[Theta] > \[Beta]\[Phi]"  
-KerrGeoFindResonance::closeSeparatrix = "No resonance or the exact result is too close to the separatrix, the value is set to the separatrix+10^(-5) instead"
+KerrGeoFindResonance::closeSeparatrix = "The exact result is too close to the separatrix and approximated to near-separatrix approximation instead"
 
 
 (* ::Subsection::Closed:: *)
@@ -341,41 +342,28 @@ KerrGeoOrbitType[a_?NumericQ, p_?NumericQ, e_?NumericQ, x_?NumericQ]:=Module[{ou
 ]
 
 
-(* ::Section:: *)
+(* ::Section::Closed:: *)
 (*Resonances*)
 
 
-(* ::Subsection:: *)
+(* ::Subsection::Closed:: *)
 (*Resonance solver*)
 
 
 Options[ResonanceSolver]={PrecisionGoal->Automatic};
 
 
-ResonanceSolver[f_, {p_, p0_?NumericQ, pSep_?NumericQ}, opts:OptionsPattern[]]:=
-Module[{pp},
-If[p0<pSep,
-	Quiet[Check[Return[p/.FindRoot[f[p], {p, pSep+10^(-5), pSep, Infinity}]],{}]];
+ResonanceSolver[f_,{p_,pSep_?NumericQ,pWF_?NumericQ,pNS_?NumericQ}, opts:OptionsPattern[]]:=
+Module[{},
+	If[pWF>pSep,Quiet[Check[Return[Re[p/.FindRoot[f[p], {p,pWF,pSep,Infinity}]]],{}]]];
+	Quiet[Check[Return[Re[p/.FindRoot[f[p],{p,pNS,pSep,Infinity}]]],{}]];
+	Quiet[Check[Return[Re[p/.FindRoot[f[p],{p,pSep,(pNS-pSep)/16*E^Pi+pSep}]]],{}]];
 	Message[KerrGeoFindResonance::closeSeparatrix];
-	Return[pSep+10^(-5)];
-];
-Quiet[Check[Return[p/.FindRoot[f[p], {p, p0, pSep, Infinity}]],{}]];
-Quiet[Check[Return[p/.FindRoot[f[p], {p, pSep+10^(-5), pSep, Infinity}]],{}]];
-Message[KerrGeoFindResonance::closeSeparatrix];
-Return[pSep+10^(-5)];
-];
+	Return[pNS];
+]
 
 
-(* ::Subsection:: *)
-(*r\[Theta]-resonances*)
-
-
-(* ::Text:: *)
-(*Reference: Brink, Geyer, and Hinderer, Phys. Rev. D 91 (2015), arXiv:1501.07728*)
-(*	- Root finding methods are based on those described in Sec.  VE*)
-
-
-(* ::Subsubsection:: *)
+(* ::Subsection::Closed:: *)
 (*Testing functions*)
 
 
@@ -400,7 +388,7 @@ ValidXQ[x_]:=Module[{xFlag=True},
 ValidResIntQ[\[Beta]r_/;\[Beta]r!=0,\[Beta]\[Theta]_/;\[Beta]\[Theta]!=0,\[Beta]\[Phi]_/;\[Beta]\[Phi]!=0]:=Module[{resFlag},
 	If[(Abs[\[Beta]r]>Abs[\[Beta]\[Theta]]), Message[KerrGeoFindResonance::invalidRatio]; resFlag=False];
 	If[(Abs[\[Beta]r]>Abs[\[Beta]\[Phi]]), Message[KerrGeoFindResonance::invalidRatio]; resFlag=False];
-	If[(\[Beta]\[Theta] \[Beta]\[Phi]<0), Message[KerrGeoFindResonance::invalidRatio]; resFlag=False];
+	If[(\[Beta]\[Theta] \[Beta]\[Phi]<0)|(\[Beta]\[Theta]>\[Beta]\[Phi]), Message[KerrGeoFindResonance::invalidRatio]; resFlag=False];
 	resFlag
 ];
 ValidResIntQ[\[Beta]r_/;\[Beta]r!=0,\[Beta]\[Theta]_/;\[Beta]\[Theta]!=0,0]:=Module[{resFlag},
@@ -412,74 +400,222 @@ ValidResIntQ[\[Beta]r_/;\[Beta]r!=0,0,\[Beta]\[Phi]_/;\[Beta]\[Phi]!=0]:=Module[
 	resFlag
 ];
 ValidResIntQ[0,\[Beta]\[Theta]_/;\[Beta]\[Theta]!=0,\[Beta]\[Phi]_/;\[Beta]\[Phi]!=0]:=Module[{resFlag},
-	If[(\[Beta]\[Theta] \[Beta]\[Phi]<0), Message[KerrGeoFindResonance::invalidRatio]; resFlag=False];
+	If[(\[Beta]\[Theta] \[Beta]\[Phi]<0)| (\[Beta]\[Theta]>\[Beta]\[Phi]), Message[KerrGeoFindResonance::invalidRatio]; resFlag=False];
 	resFlag
 ];
 
 
-(* ::Subsubsection:: *)
-(*Useful functions for root-finding*)
+(* ::Subsection::Closed:: *)
+(*Frequency ratio functions*)
 
 
-(* ::Text:: *)
-(*See Eq 25 for definitions of these quantities*)
+r\[Theta]Ratio[a_, p_, e_, x_]:=
+	Module[{constants, radialRoots, polarRoots,\[CapitalUpsilon]r,\[CapitalUpsilon]\[Theta]},
+	constants = Values[KerrGeoConstantsOfMotion[a,p,e,x]];
+	radialRoots = KerrGeodesics`OrbitalFrequencies`Private`KerrGeoRadialRoots[a,p,e,x,constants[[1]],constants[[3]]];
+	polarRoots = KerrGeodesics`OrbitalFrequencies`Private`KerrGeoPolarRoots[a,p,e,x];
+	\[CapitalUpsilon]r = KerrGeodesics`OrbitalFrequencies`Private`KerrGeoMinoFrequencyr[a,p,e,x,constants,radialRoots];
+	\[CapitalUpsilon]\[Theta] = KerrGeodesics`OrbitalFrequencies`Private`KerrGeoMinoFrequency\[Theta][a,p,e,x,constants,polarRoots];
+	Return[\[CapitalUpsilon]r/\[CapitalUpsilon]\[Theta]];
+]
 
 
-del1y1[a_/;a!=0,p_,e_,x_/;x^2<1]:=-e p Sqrt[\[Pi]p[a,p,e,x]^2-4 \[Pi]x[a,p,e,x]]/((1-e^2)\[Pi]x[a,p,e,x]+p^2-p \[Pi]p[a,p,e,x]);
-del2y2[a_/;a!=0,p_,e_,x_/;x^2<1]:=(1-e^2)a^4 (1-x^2)^2/((1-e^2)a^4 (1-x^2)^2-2p^2 \[Pi]x[a,p,e,x]);
-y1y2[a_/;a!=0,p_,e_,x_/;x^2<1]:=2a^2 (1-x^2)((1-e^2)\[Pi]x[a,p,e,x]+p^2-p \[Pi]p[a,p,e,x])/(a^4(e^2-1)(1-x^2)^2+2 p^2 \[Pi]x[a,p,e,x]);
+r\[Phi]Ratio[a_, p_, e_, x_/;x!=0]:=
+	Module[{constants, radialRoots, polarRoots,\[CapitalUpsilon]r,\[CapitalUpsilon]\[Phi]},
+	constants = Values[KerrGeoConstantsOfMotion[a,p,e,x]];
+	radialRoots = KerrGeodesics`OrbitalFrequencies`Private`KerrGeoRadialRoots[a,p,e,x,constants[[1]],constants[[3]]];
+	polarRoots=KerrGeodesics`OrbitalFrequencies`Private`KerrGeoPolarRoots[a,p,e,x];
+	\[CapitalUpsilon]r = KerrGeodesics`OrbitalFrequencies`Private`KerrGeoMinoFrequencyr[a,p,e,x,constants,radialRoots];
+	\[CapitalUpsilon]\[Phi] = KerrGeodesics`OrbitalFrequencies`Private`KerrGeoMinoFrequency\[Phi][a,p,e,x,constants,radialRoots,polarRoots];
+	Return[Sign[x]\[CapitalUpsilon]r/\[CapitalUpsilon]\[Phi]];
+]
 
-del1y1[a_,p_,e_,x_/;x^2==1]:=-e \[Pi]p[a,p,e,x]/(p-\[Pi]p[a,p,e,x]);
-del2y2[a_,p_,e_,x_/;x^2==1]:=0;
-y1y2[a_,p_,e_,x_/;x^2==1]:=(p-\[Pi]p[a,p,e,x])/(p+2\[Pi]p[a,p,e,x]);
-
-del1y1[0,p_,e_,x_/;x^2<1]:=del1y1[0,p,e,1];
-del2y2[0,p_,e_,x_/;x^2<1]:=del2y2[0,p,e,1];
-y1y2[0,p_,e_,x_/;x^2<1]:=y1y2[0,p,e,1];
-
-
-(* ::Text:: *)
-(*\[Pi]p = r3 + r4, \[Pi]x = r3*r4, where (dr/d\[Lambda])^2 = -(\[Mu]^2+ \[ScriptCapitalE]^2)(r-r1)(r-r2)(r-r3)(r-r4) with r1 >= r2 >= r3 > r4. *)
-
-
-\[Pi]p[a_/;a!=0,p_,e_,x_/;x^2<1]:=((-p^2 + a^2*(-1 + e^2)*(-1 + x^2))*(a^2*(-1 + x^2) + \[Pi]x[a,p,e,x]))/(2*a^2*p*(-1 + x^2));
-
-\[Pi]p[0,p_,e_,x_/;x^2<1]:=2p/(p-4);
-
-\[Pi]p[a_,p_,e_/;e<1,1]:=(2*(a^4*(-1+e^2)*p+(-4+p)*p^3+a^2*p^2*(3+e^2+p)-2*Sqrt[a^2*p^3*(a^4*(-1+e^2)^2+(-4*e^2+(-2+p)^2)*p^2+2*a^2*p*(-2+p+e^2*(2+p)))]))/(a^4*(-1+e^2)^2+(-4+p)^2*p^2+2*a^2*(-1+e^2)*p*(4+p));
-\[Pi]p[a_,p_,e_/;e==1,1]:=(-4*Sqrt[p^3*(a^3+a*(-2+p)*p)^2]+2*p*(-a^4+(-4+p)*p^2+a^2*p*(3+p)))/(((a-p)^2-4*p)*(-4*p+(a+p)^2));
-
-\[Pi]p[a_,p_,e_/;e<1,-1]:=(2*(a^4*(-1+e^2)*p+(-4+p)*p^3+a^2*p^2*(3+e^2+p)+2*Sqrt[a^2*p^3*(a^4*(-1+e^2)^2+(-4*e^2+(-2+p)^2)*p^2+2*a^2*p*(-2+p+e^2*(2+p)))]))/(a^4*(-1+e^2)^2+(-4+p)^2*p^2+2*a^2*(-1+e^2)*p*(4+p));
-\[Pi]p[a_,p_,e_/;e==1,-1]:=(2*(-(a^4*p)+(-4+p)*p^3+a^2*p^2*(3+p)+2*Sqrt[p^3*(a^3+a*(-2+p)*p)^2]))/(a^4+(-4+p)^2*p^2-2*a^2*p*(4+p));
+r\[Phi]Ratio[a_, p_, e_, x_/;x==0]:=
+	Module[{constants, radialRoots, polarRoots,\[CapitalUpsilon]\[Phi]r,\[CapitalUpsilon]\[Phi]\[Theta],\[CapitalUpsilon]r},
+	constants = Values[KerrGeoConstantsOfMotion[a,p,e,x]];
+	radialRoots = KerrGeodesics`OrbitalFrequencies`Private`KerrGeoRadialRoots[a,p,e,x,constants[[1]],constants[[3]]];
+	polarRoots=KerrGeodesics`OrbitalFrequencies`Private`KerrGeoPolarRoots[a,p,e,x];
+	\[CapitalUpsilon]\[Phi]r=KerrGeodesics`OrbitalFrequencies`Private`KerrGeoMinoFrequency\[Phi]r[a,p,e,x,constants,radialRoots];
+	\[CapitalUpsilon]\[Phi]\[Theta]=KerrGeodesics`OrbitalFrequencies`Private`KerrGeoMinoFrequency\[Phi]\[Theta][a,p,e,x,constants,polarRoots];
+	\[CapitalUpsilon]r=KerrGeodesics`OrbitalFrequencies`Private`KerrGeoMinoFrequencyr[a,p,e,x,constants,radialRoots];
+	Return[{\[CapitalUpsilon]r/(\[CapitalUpsilon]\[Phi]\[Theta]+\[CapitalUpsilon]\[Phi]r), \[CapitalUpsilon]r/(\[CapitalUpsilon]\[Phi]\[Theta]-\[CapitalUpsilon]\[Phi]r)}];
+]
 
 
-\[Pi]x[a_,p_,e_,x_/;x>=0]:=(a^2*(1 - x^2)*((-4 + p)*p^7 + a^8*(-1 + e^2)^4*(-1 + x^2)^2 + 2*a^6*(-1 + e^2)^2*p*(1 - x^2)*((1 + e^2)*p + (-2 + p + e^2*(2 + p))*(1 - x^2)) + 
-   a^4*p^3*((-3 + 2*e^2 + e^4)*p + 4*(-4 + 3*p + e^4*(4 + p))*(1 - x^2) + (-1 + e^2)*(-4 + e^2*(-12 + p) + 3*p)*(-1 + x^2)^2) + 
-   2*a^2*p^2*((-1 - e^2)*p^4*(-2 + x^2) + 8*(-1 + e^2)*p^2*(-1 + x^2) + 2*p^3*(-3 - e^2 + 4*(1 + e^2)*x^2) - 
-     4*Sqrt[-1/(a^2*p)(((a^4*(-1 + e^2)^2 + (-4*e^2 + (-2 + p)^2)*p^2 + 2*a^2*p*(-2 + p + e^2*(2 + p)))*x^2*(-p^2 + a^2*(-1 + e)^2*(-1 + x^2))*(-p^2 + a^2*(1 + e)^2*(-1 + x^2))*
-          (-p^2 + a^2*(-1 + e^2)*(-1 + x^2))))])))/((-4 + p)^2*p^6 + a^8*(-1 + e^2)^4*(-1 + x^2)^2 + 2*a^2*p^5*((-1 + e^2)*(4 + p) + (-4 + e^2*(-12 + p) + 3*p)*(1 - x^2)) + 
-  2*a^6*(-1 + e^2)^2*p^2*(-1 + x^2)*(-2 + 3*x^2 + e^2*(-2 + x^2)) + a^4*p^3*(-8*(-1 + e^2)^2*(1 - 3*x^2 + 2*x^4) + p*((-1 + e^2)^2 - 4*(-1 + e^4)*(-1 + x^2) + (3 + e^2)^2*(-1 + x^2)^2)));
+\[Phi]\[Theta]Ratio[a_, p_, e_, x_/;x!=0]:=
+	Module[{constants, radialRoots, polarRoots,\[CapitalUpsilon]\[Theta],\[CapitalUpsilon]\[Phi]},
+	constants = Values[KerrGeoConstantsOfMotion[a,p,e,x]];
+	radialRoots = KerrGeodesics`OrbitalFrequencies`Private`KerrGeoRadialRoots[a,p,e,x,constants[[1]],constants[[3]]];
+	polarRoots=KerrGeodesics`OrbitalFrequencies`Private`KerrGeoPolarRoots[a,p,e,x];
+	\[CapitalUpsilon]\[Theta] = KerrGeodesics`OrbitalFrequencies`Private`KerrGeoMinoFrequency\[Theta][a,p,e,x,constants,polarRoots];
+	\[CapitalUpsilon]\[Phi] = KerrGeodesics`OrbitalFrequencies`Private`KerrGeoMinoFrequency\[Phi][a,p,e,x,constants,radialRoots,polarRoots];
+	Return[Sign[x]\[CapitalUpsilon]\[Phi]/\[CapitalUpsilon]\[Theta]];
+]
 
-\[Pi]x[a_,p_,e_,x_/;x<0]:=(a^2*(1 - x^2)*((-4 + p)*p^7 + a^8*(-1 + e^2)^4*(-1 + x^2)^2 + 2*a^6*(-1 + e^2)^2*p*(1 - x^2)*((1 + e^2)*p + (-2 + p + e^2*(2 + p))*(1 - x^2)) + 
-   a^4*p^3*((-3 + 2*e^2 + e^4)*p + 4*(-4 + 3*p + e^4*(4 + p))*(1 - x^2) + (-1 + e^2)*(-4 + e^2*(-12 + p) + 3*p)*(-1 + x^2)^2) + 
-   2*a^2*p^2*(-((1 + e^2)*p^4*(-2 + x^2)) + 8*(-1 + e^2)*p^2*(-1 + x^2) + 2*p^3*(-3 - e^2 + 4*(1 + e^2)*x^2) + 
-     4*Sqrt[-1/(a^2*p)(((a^4*(-1 + e^2)^2 + (-4*e^2 + (-2 + p)^2)*p^2 + 2*a^2*p*(-2 + p + e^2*(2 + p)))*x^2*(-p^2 + a^2*(-1 + e)^2*(-1 + x^2))*(-p^2 + a^2*(1 + e)^2*(-1 + x^2))*
-          (-p^2 + a^2*(-1 + e^2)*(-1 + x^2))))])))/((-4 + p)^2*p^6 + a^8*(-1 + e^2)^4*(-1 + x^2)^2 + 2*a^2*p^5*((-1 + e^2)*(4 + p) + (-4 + e^2*(-12 + p) + 3*p)*(1 - x^2)) + 
-  2*a^6*(-1 + e^2)^2*p^2*(-1 + x^2)*(-2 + 3*x^2 + e^2*(-2 + x^2)) + a^4*p^3*(-8*(-1 + e^2)^2*(1 - 3*x^2 + 2*x^4) + p*((-1 + e^2)^2 - 4*(-1 + e^4)*(-1 + x^2) + (3 + e^2)^2*(-1 + x^2)^2)));
-
-
-(* ::Text:: *)
-(*Carlson's integral of the first kind, which is defined in Eq. (B12) of reference listed above*)
-
-
-Rf[0,alpha_,beta_]:=beta^(-1/2)EllipticK[1-alpha/beta];
-
-
-(* ::Text:: *)
-(*r\[Theta] ratio*)
+\[Phi]\[Theta]Ratio[a_, p_, e_, x_/;x==0]:=
+	Module[{constants, radialRoots, polarRoots,\[CapitalUpsilon]\[Phi]r,\[CapitalUpsilon]\[Phi]\[Theta],\[CapitalUpsilon]\[Theta]},
+	constants = Values[KerrGeoConstantsOfMotion[a,p,e,x]];
+	radialRoots = KerrGeodesics`OrbitalFrequencies`Private`KerrGeoRadialRoots[a,p,e,x,constants[[1]],constants[[3]]];
+	polarRoots=KerrGeodesics`OrbitalFrequencies`Private`KerrGeoPolarRoots[a,p,e,x];
+	\[CapitalUpsilon]\[Phi]r=KerrGeodesics`OrbitalFrequencies`Private`KerrGeoMinoFrequency\[Phi]r[a,p,e,x,constants,radialRoots];
+	\[CapitalUpsilon]\[Phi]\[Theta]=KerrGeodesics`OrbitalFrequencies`Private`KerrGeoMinoFrequency\[Phi]\[Theta][a,p,e,x,constants,polarRoots];
+	\[CapitalUpsilon]\[Theta]=KerrGeodesics`OrbitalFrequencies`Private`KerrGeoMinoFrequency\[Theta][a,p,e,x,constants,polarRoots];
+	Return[{(\[CapitalUpsilon]\[Phi]\[Theta]+\[CapitalUpsilon]\[Phi]r)/\[CapitalUpsilon]\[Theta], (\[CapitalUpsilon]\[Phi]\[Theta]-\[CapitalUpsilon]\[Phi]r)/\[CapitalUpsilon]\[Theta]}];
+]
 
 
-r\[Theta]Ratio[a_, p_, e_, x_]:=Sqrt[y1y2[a,p,e,x]]Rf[0,1+del2y2[a,p,e,x],1-del2y2[a,p,e,x]]/Rf[0,1+del1y1[a,p,e,x],1-del1y1[a,p,e,x]];
+(* ::Subsection::Closed:: *)
+(*Near-separatrix functions*)
+
+
+Dr2MinusDr3[a_,e_,x_,ps_,constants_]:=
+Module[{r1, r2, r3, r4, S, P, A11, A12, A21, A22, B1, B2, det,dP,dS},
+	{r1,r2,r3,r4} = KerrGeodesics`OrbitalFrequencies`Private`KerrGeoRadialRoots[a,ps,e,x,constants[[1]],constants[[3]]];
+	r3 = r2;
+	S = r3+r4;
+	P= r3 r4;
+	A11 = 4S(a^2(e^2-1)(e^2-ps-1)+ps(e^2(ps+4)-ps^2+3ps-4))+8ps(a^2-ps)(e^2+ps-1)-8P (e^2+ps-1)^2;
+	A12 = (
+        4P(a^2(e^2-1)(e^2-ps-1)+ps(e^2(ps+4)-ps^2+3ps-4))
+        +2S(-a^4(e^2-1)^2-2a^2(e^2-1)ps(ps+4)-(ps-4)^2 ps^2)
+        +4ps(a^4(e^2-1)+a^2 ps(e^2+ps+3)+(ps-4)ps^2)
+    );
+    A21 = ps^2-a^2(e^2-1)(x^2 - 1);
+    A22 = 2a^2 ps (x^2 - 1);
+    B1 = (
+        8(e^2-1)P(P-2^S)
+        +4ps^3(S - 2)^2
+        +4a^4(e^2(-S)+2ps+S)
+        +8ps(-P(e^2(S-2)+3S+2)+P^2+4S^2)
+        +12ps^2(P(S+2)-2(S-2)S)
+        -4a^2(
+            3ps^2(S+2)-(e^2-1)(P(S-2)+2S^2)+ps(S(-(e^2(S-2))+S+6)+4P)
+        )
+    );
+    B2 = -2(a^2(x^2-1)(ps + S)+ps P);
+    det = A11*A22-A12*A21;
+    dP = (A22*B1-A12*B2)/det;
+    dS = (-A21*B1+A11*B2)/det;
+    Return[1/(1+e)-(dP-r3 dS)/(S-2r3)];
+]
+Cfactor[a_, e_, x_, ps_, constants_]:=
+Module[{En,L,Q,r1,r2,r3,r4},
+	{r1, r2, r3, r4}=KerrGeodesics`OrbitalFrequencies`Private`KerrGeoRadialRoots[a,ps,e,x,constants[[1]],constants[[3]]];
+	r3=r2;
+	If[e==1, Return[1/(r2-r4)],Return[(r1-r4)/(r1-r3)/(r2-r4)]];
+]
+
+
+Fr\[Theta][a_, e_, x_, ps_, constants_]:=
+Module[{En,L,Q,r1,r2,r3,r4,zp,zm},
+	{En,L,Q}=constants;
+	{r1, r2, r3, r4}=KerrGeodesics`OrbitalFrequencies`Private`KerrGeoRadialRoots[a,ps,e,x,En,Q];
+	r3=r2;
+	{zp,zm}=KerrGeodesics`OrbitalFrequencies`Private`KerrGeoPolarRoots[a,ps,e,x];
+	If[e==1, Return[2 Sqrt[2(r2-r4)]/Sqrt[L^2+Q]*Pi/4]];
+	Return[Sqrt[(r1-r3)(r2-r4)(1-En^2)/zp^2]EllipticK[zm^2a^2(1-En^2)/zp^2]];
+];
+
+FK[a_, e_, x_, ps_, constants_]:=
+Module[{En,L,Q,r1,r2,r3,r4,zp,zm,rp,rm, term1, term2},
+	{En,L,Q}=constants;
+	{r1, r2, r3, r4}=KerrGeodesics`OrbitalFrequencies`Private`KerrGeoRadialRoots[a,ps,e,x,En,Q];
+	r3=r2;
+	{zp,zm}=KerrGeodesics`OrbitalFrequencies`Private`KerrGeoPolarRoots[a,ps,e,x];
+	rp = 1+Sqrt[1-a^2];
+	rm = 1-Sqrt[1-a^2];
+	term1 =1/Fr\[Theta][a,e,x,ps,constants];
+	If[e==1,
+		term2 = 2a/(Pi Sqrt[2(r2-r4)])(2En r3-a L)/(r3-rp)/(r3-rm);
+		If[x==0,
+			Return[{term1+term2, term1-term2}],
+			Return[term1+Sign[x]term2]
+		];,
+		term2 = 2a/(Pi Sqrt[(1-En^2)(r1-r3)(r2-r4)])(2En r3-a L)/(r3-rp)/(r3-rm);
+		If[x==0,
+			Return[{term1+term2, term1-term2}],
+			Return[2 Abs[L]/(Pi zp)EllipticPi[zm^2,zm^2a^2(1-En^2)/zp^2]term1+Sign[x]term2];
+		];
+	];
+];
+
+Fplus[a_, e_, x_, ps_, constants_]:=
+Module[{En,L,Q,r1,r2,r3,r4,zp,zm,rp,rm, term1, term2},
+	{En,L,Q}=constants;
+	{r1, r2, r3, r4}=KerrGeodesics`OrbitalFrequencies`Private`KerrGeoRadialRoots[a,ps,e,x,En,Q];
+	r3=r2;
+	rp = 1+Sqrt[1-a^2];
+	rm = 1-Sqrt[1-a^2];
+	
+	If[e==1,
+		term1 = 2a/(Pi Sqrt[2(r2-r4)])(2En rp-a L)/(r3-rp)/(rp-rm)r3/rp;
+		term2 = (r2-r4)/(r2-rp);,
+		term1 = 2a/(Pi Sqrt[(1-E^2)(r1-r3)(r2-r4)])(2En rp-a L)/(r3-rp)/(rp-rm)(r1-r3)/(r1-rp);
+		term2 = (r1-rp)/(r2-rp)(r2-r4)/(r1-r4);
+	];
+	Return[-term1 Sqrt[term2]CarlsonRC[term2,1]];
+];
+
+Fminus[a_, e_, x_, ps_, constants_]:=
+Module[{En,L,Q,r1,r2,r3,r4,zp,zm,rp,rm, term1, term2},
+	{En,L,Q}=constants;
+	{r1, r2, r3, r4}=KerrGeodesics`OrbitalFrequencies`Private`KerrGeoRadialRoots[a,ps,e,x,En,Q];
+	r3=r2;
+	rp = 1+Sqrt[1-a^2];
+	rm = 1-Sqrt[1-a^2];
+	
+	If[e==1,
+		term1 = 2a/(Pi Sqrt[2(r2-r4)])(2En rm-a L)/(r3-rm)/(rp-rm)r3/rm;
+		term2 = (r2-r4)/(r2-rm);,
+		term1 = 2a/(Pi Sqrt[(1-E^2)(r1-r3)(r2-r4)])(2En rm-a L)/(r3-rm)/(rp-rm)(r1-r3)/(r1-rm);
+		term2 = (r1-rm)/(r2-rm)(r2-r4)/(r1-r4);
+	];
+	Return[term1 Sqrt[term2]CarlsonRC[term2,1]];
+];
+
+
+
+pNearSeparatrixr\[Theta][a_, e_, x_, ratio_, ps1_:Automatic]:=
+Module[{ps=ps1, constants},
+	If[ps==Automatic, ps=KerrGeoSeparatrix[a,e,x]];
+	If[e==0, Return[ps]];
+	constants=Values[KerrGeoConstantsOfMotion[a,ps,e,x]];
+	Return[ps+16/Dr2MinusDr3[a,e,x,ps,constants]/Cfactor[a,e,x,ps,constants]Exp[-2Fr\[Theta][a,e,x,ps,constants]/Abs[ratio]]]
+]
+
+
+pNearSeparatrixr\[Phi][a_, e_, x_, ratio_, ps1_:Automatic]:=
+Module[{fk, ps=ps1,constants},
+	If[ps==Automatic, ps=KerrGeoSeparatrix[a,e,x]];
+	If[e==0, Return[ps]];
+	constants=Values[KerrGeoConstantsOfMotion[a,ps,e,x]];
+	If[x==0,
+		If[ratio>0,fk=FK[a,e,x,ps,constants][[1]], 
+			If[ratio<0, fk=FK[a,e,x,ps,constants][[2]]]];,
+		fk=FK[a,e,x,ps,constants];
+	];
+	Return[ps+16/Dr2MinusDr3[a,e,x,ps,constants]/Cfactor[a,e,x,ps,constants]Exp[2/fk Sign[ratio](Fplus[a,e,x,ps,constants]+Fminus[a,e,x,ps,constants])-1/ratio]];
+]
+
+
+pNearSeparatrix\[Phi]\[Theta][a_, e_, x_, ratio_, ps1_:Automatic]:=
+Module[{fk, fr\[Theta], ps=ps1,constants},
+	If[ps==Automatic, ps=KerrGeoSeparatrix[a,e,x]];
+	If[e==0, Return[ps]];
+	constants=Values[KerrGeoConstantsOfMotion[a,ps,e,x]];
+	If[x==0,
+		If[ratio>1,fk=FK[a,e,x,ps,constants][[1]], 
+			If[ratio<1, fk=FK[a,e,x,ps,constants][[2]]]];,
+		fk=FK[a,e,x,ps,constants];
+	];
+	fr\[Theta]=Fr\[Theta][a,e,x,ps,constants];
+	If[ratio==fk fr\[Theta],Return[ps]];
+	Return[ps+16/Dr2MinusDr3[a,e,x,ps,constants]/Cfactor[a,e,x,ps,constants]Exp[2fr\[Theta] (Fplus[a,e,x,ps,constants]+Fminus[a,e,x,ps,constants])/Abs[fk fr\[Theta]-ratio]]]
+]
+
+
+(* ::Subsection::Closed:: *)
+(*r\[Theta]-resonances*)
 
 
 (* ::Subsubsection::Closed:: *)
@@ -495,7 +631,7 @@ Options[KerrGeoOrbitRThetaResonantP]={PrecisionGoal->Automatic};
 
 
 KerrGeoOrbitRThetaResonantP[a_?NumericQ, e_?NumericQ, x_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Theta]_Integer}, opts:OptionsPattern[]]:=
-Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest,pSep},
+Module[{pg,ratio,argpg,resonantEqn,pWF,pNS,pp,pgTest,pSep},
 	(*See if the user specified some precision goal *)
 	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Theta],0],Abort[]];
 	pg=OptionValue[PrecisionGoal];
@@ -503,24 +639,26 @@ Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest,pSep},
 	If[x>0&&ratio<0, Message[KerrGeoFindResonance::invalidPrograde]; Abort[]];
 	If[x<0&&ratio>0, Message[KerrGeoFindResonance::invalidRetrograde]; Abort[]];
 	(* pStar provides an initial guess for p. Note that p = pStar for e = 0 and a = 0*)
-	pStar=6/(1-ratio^2); (* See Eq 30 *)
 	pSep=KerrGeoSeparatrix[a,e,x];
+	pWF=6/(1-ratio^2);
+	pNS=pNearSeparatrixr\[Theta][a,e,x,ratio,pSep];
+	
 	
 	(* Resonant condition defined by the equation below *)
-	resonantEqn[p_?NumericQ]:=r\[Theta]Ratio[a, p, e, x]-Abs[ratio];
+	resonantEqn[p_?NumericQ]:=r\[Theta]Ratio[a, p, e, x]Abs[\[Beta]\[Theta]]-\[Beta]r;
 	
 	(* Working precision of the root-finding method is based on the precision specified
 	 by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
 	 is the default precision if not other precision specifications are made. *)
-	argpg=Precision[{resonantEqn[pStar],a,e,x,ratio}];
+	argpg=Precision[{resonantEqn[pNS],a,e,x,ratio}];
 	If[argpg==$MachinePrecision,pg=argpg];
 	If[(Not@NumericQ[pg]||pg>argpg),pg=argpg];
 	If[pg==Infinity,pg=$MachinePrecision];
 	
 	If[pg==$MachinePrecision,
-		ResonanceSolver[resonantEqn,{pp, pStar, pSep}],
-		ResonanceSolver[resonantEqn,{pp, pStar, pSep, PrecisionGoal->pg, WorkingPrecision->pg}],
-		ResonanceSolver[resonantEqn,{pp, pStar, pSep, PrecisionGoal->pg, WorkingPrecision->pg}]
+		ResonanceSolver[resonantEqn,{pp, pSep, pWF, pNS}],
+		ResonanceSolver[resonantEqn,{pp, pSep, pWF, pNS}, PrecisionGoal->pg, WorkingPrecision->pg],
+		ResonanceSolver[resonantEqn,{pp, pSep, pWF, pNS}, PrecisionGoal->pg, WorkingPrecision->pg]
 	]
 ];
 
@@ -533,7 +671,7 @@ Options[KerrGeoOrbitRThetaResonantE]={PrecisionGoal->Automatic};
 
 
 KerrGeoOrbitRThetaResonantE[a_?NumericQ, p_?NumericQ, x_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Theta]_Integer}, opts:OptionsPattern[]]:=
-Module[{pg,argpg,resonantEqn,e0Test,e1Test,eGuess,ee,ratio},
+Module[{pg,argpg,resonantEqn,p0,p1,eGuess,ee,ratio},
 	(*See if the user specified some precision goal *)
 	If[Not@ValidAQ[a]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Theta],0],Abort[]];
 	pg=OptionValue[PrecisionGoal];
@@ -543,15 +681,15 @@ Module[{pg,argpg,resonantEqn,e0Test,e1Test,eGuess,ee,ratio},
 	
 	(* Test to see if there is an eccentricity that will lead to a bound orbital resonance 
 	 based on the provided values of a, p, x *)
-	e0Test=KerrGeoOrbitRThetaResonantP[a,0,x,{\[Beta]r,\[Beta]\[Theta]}, opts];
-	e1Test=KerrGeoOrbitRThetaResonantP[a,1,x,{\[Beta]r,\[Beta]\[Theta]}, opts];
-	If[p<e0Test||e1Test<p, Message[KerrGeoFindResonance::noresonance, e0Test, e1Test]; Abort[];];
-	If[p==e0Test,Return[0]];
-	If[p==e1Test,Return[1]];
-	eGuess=(p-e0Test)/(e1Test-e0Test);
+	p0=KerrGeoOrbitRThetaResonantP[a,0,x,{\[Beta]r,\[Beta]\[Theta]}, opts];
+	p1=KerrGeoOrbitRThetaResonantP[a,1,x,{\[Beta]r,\[Beta]\[Theta]}, opts];
+	If[p<p0||p1<p, Message[KerrGeoFindResonance::noresonance, p0, p1]; Abort[];];
+	If[p==p0,Return[0]];
+	If[p==p1,Return[1]];
+	eGuess=(p-p0)/(p1-p0);
 
 	(* Resonant condition defined by the equation below *)
-	resonantEqn[e_?NumericQ]:=r\[Theta]Ratio[a, p, e, x]-Abs[ratio];
+	resonantEqn[e_?NumericQ]:=r\[Theta]Ratio[a, p, e, x]Abs[\[Beta]\[Theta]]-\[Beta]r;
 	
 	(* Working precision of the root-finding method is based on the precision specified
 	 by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
@@ -577,7 +715,7 @@ Options[KerrGeoOrbitRThetaResonantX]={PrecisionGoal->Automatic};
 
 
 KerrGeoOrbitRThetaResonantX[a_?NumericQ, p_?NumericQ, e_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Theta]_Integer}, opts:OptionsPattern[]]:=
-Module[{pg,argpg,resonantEqn,x0Test,x1Test,xGuess,xx,xxx,ratio},
+Module[{pg,argpg,resonantEqn,p0,p1,xGuess,xx,ratio},
 	(*See if the user specified some precision goal *)
 	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Theta],0],Abort[]];
 
@@ -585,17 +723,17 @@ Module[{pg,argpg,resonantEqn,x0Test,x1Test,xGuess,xx,xxx,ratio},
 	ratio=\[Beta]r/\[Beta]\[Theta];
 	(* Test to see if there is an inclination angle that will lead to a bound orbital resonance 
 	 based on the provided values of a, p, e *)
-	x0Test=KerrGeoOrbitRThetaResonantP[a,e,0,{\[Beta]r,\[Beta]\[Theta]},opts];
-	x1Test=KerrGeoOrbitRThetaResonantP[a,e,Sign[ratio],{\[Beta]r,\[Beta]\[Theta]},opts];
+	p0=KerrGeoOrbitRThetaResonantP[a,e,0,{\[Beta]r,\[Beta]\[Theta]},opts];
+	p1=KerrGeoOrbitRThetaResonantP[a,e,Sign[ratio],{\[Beta]r,\[Beta]\[Theta]},opts];
 	
-	If[ratio>0 && (p<x1Test||x0Test<p), Message[KerrGeoFindResonance::noresonance, x1Test, x0Test]; Abort[];];
-	If[ratio<0 && (p<x0Test||x1Test<p), Message[KerrGeoFindResonance::noresonance, x0Test, x1Test]; Abort[];];
-	If[p==x0Test,Return[0]];
-	If[p==x1Test,Return[Sign[ratio]]];
-	xGuess=Sign[ratio](p-x0Test)/(x1Test-x0Test);
+	If[ratio>0 && (p<p1||p0<p), Message[KerrGeoFindResonance::noresonance, x1Test, x0Test]; Abort[];];
+	If[ratio<0 && (p<p0||p1<p), Message[KerrGeoFindResonance::noresonance, x0Test, x1Test]; Abort[];];
+	If[p==p0,Return[0]];
+	If[p==p1,Return[Sign[ratio]]];
+	xGuess=Sign[ratio](p-p1)/(p1-p0);
 
 	(* Resonant condition defined by the equation below *)
-	resonantEqn[x_?NumericQ]:=r\[Theta]Ratio[a, p, e, x]-Abs[ratio];
+	resonantEqn[x_?NumericQ]:=r\[Theta]Ratio[a, p, e, x]Abs[\[Beta]\[Theta]]-\[Beta]r;
 	
 	(* Working precision of the root-finding method is based on the precision specified
 	 by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
@@ -606,77 +744,15 @@ Module[{pg,argpg,resonantEqn,x0Test,x1Test,xGuess,xx,xxx,ratio},
 	If[pg==Infinity,pg=$MachinePrecision];
 
 	If[pg==$MachinePrecision,
-		xxx=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess}]],
-		xxx=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess},PrecisionGoal->pg,WorkingPrecision->0.95argpg]],
-		xxx=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess},PrecisionGoal->pg,WorkingPrecision->0.95argpg]]
+		Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess}]],
+		Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess},PrecisionGoal->pg,WorkingPrecision->0.95argpg]],
+		Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess},PrecisionGoal->pg,WorkingPrecision->0.95argpg]]
 	]
 ];
 
 
-(* ::Subsection:: *)
+(* ::Subsection::Closed:: *)
 (*r\[Phi]-resonances*)
-
-
-(* ::Subsubsection::Closed:: *)
-(*Testing functions*)
-
-
-(* ::Text:: *)
-(*Same as those of r\[Theta]-resonance*)
-
-
-(* ::Subsubsection::Closed:: *)
-(*Useful functions for root-finding*)
-
-
-En2[a_, p_, e_/;e<1, x_]:=1-(2(1-e^2))/(2p+(1-e^2)\[Pi]p[a,p,e,x]);
-En2[a_,p_,1, x_]:=1;
-
-L2[a_, p_, e_, x_]:=(2 (a^2 (-1+e^2)+p^2) (a^2-\[Pi]x[a,p,e,x])+4 a^2 p \[Pi]p[a,p,e,x])/(a^2 (2 p+(1-e^2)\[Pi]p[a,p,e,x]));
-L2[a_, p_, e_, 0]:=0;
-
-Q[a_, p_, e_, x_/;x^2<1]:=(2 p^2 \[Pi]x[a,p,e,x])/(a^2 (2 p+(1-e^2)\[Pi]p[a,p,e,x]));
-Q[a_, p_, e_, x_/;x^2==1]:=0;
-
-r3[a_, p_, e_, x_/;x^2<1]:=(\[Pi]p[a,p,e,x]+Sqrt[\[Pi]p[a,p,e,x]^2-4 \[Pi]x[a,p,e,x]])/2;
-r3[a_, p_, e_, x_/;x^2==1]:=\[Pi]p[a,p,e,x];
-
-r4[a_, p_, e_, x_/;x^2<1]:=(\[Pi]p[a,p,e,x]-Sqrt[\[Pi]p[a,p,e,x]^2-4 \[Pi]x[a,p,e,x]])/2;
-r4[a_, p_, e_, x_/;x^2==1]:=0;
-
-
-\[Pi]xReduced[a_,p_,e_,x_/;x>=0]:=(a^2*((-4 + p)*p^7 + a^8*(-1 + e^2)^4*(-1 + x^2)^2 + 2*a^6*(-1 + e^2)^2*p*(1 - x^2)*((1 + e^2)*p + (-2 + p + e^2*(2 + p))*(1 - x^2)) + 
-   a^4*p^3*((-3 + 2*e^2 + e^4)*p + 4*(-4 + 3*p + e^4*(4 + p))*(1 - x^2) + (-1 + e^2)*(-4 + e^2*(-12 + p) + 3*p)*(-1 + x^2)^2) + 
-   2*a^2*p^2*((-1 - e^2)*p^4*(-2 + x^2) + 8*(-1 + e^2)*p^2*(-1 + x^2) + 2*p^3*(-3 - e^2 + 4*(1 + e^2)*x^2) - 
-     4*Sqrt[-1/(a^2*p)(((a^4*(-1 + e^2)^2 + (-4*e^2 + (-2 + p)^2)*p^2 + 2*a^2*p*(-2 + p + e^2*(2 + p)))*x^2*(-p^2 + a^2*(-1 + e)^2*(-1 + x^2))*(-p^2 + a^2*(1 + e)^2*(-1 + x^2))*
-          (-p^2 + a^2*(-1 + e^2)*(-1 + x^2))))])))/((-4 + p)^2*p^6 + a^8*(-1 + e^2)^4*(-1 + x^2)^2 + 2*a^2*p^5*((-1 + e^2)*(4 + p) + (-4 + e^2*(-12 + p) + 3*p)*(1 - x^2)) + 
-  2*a^6*(-1 + e^2)^2*p^2*(-1 + x^2)*(-2 + 3*x^2 + e^2*(-2 + x^2)) + a^4*p^3*(-8*(-1 + e^2)^2*(1 - 3*x^2 + 2*x^4) + p*((-1 + e^2)^2 - 4*(-1 + e^4)*(-1 + x^2) + (3 + e^2)^2*(-1 + x^2)^2)));
-\[Pi]xReduced[a_,p_,e_,x_/;x<0]:=(a^2*((-4 + p)*p^7 + a^8*(-1 + e^2)^4*(-1 + x^2)^2 + 2*a^6*(-1 + e^2)^2*p*(1 - x^2)*((1 + e^2)*p + (-2 + p + e^2*(2 + p))*(1 - x^2)) + 
-   a^4*p^3*((-3 + 2*e^2 + e^4)*p + 4*(-4 + 3*p + e^4*(4 + p))*(1 - x^2) + (-1 + e^2)*(-4 + e^2*(-12 + p) + 3*p)*(-1 + x^2)^2) + 
-   2*a^2*p^2*(-((1 + e^2)*p^4*(-2 + x^2)) + 8*(-1 + e^2)*p^2*(-1 + x^2) + 2*p^3*(-3 - e^2 + 4*(1 + e^2)*x^2) + 
-     4*Sqrt[-1/(a^2*p)(((a^4*(-1 + e^2)^2 + (-4*e^2 + (-2 + p)^2)*p^2 + 2*a^2*p*(-2 + p + e^2*(2 + p)))*x^2*(-p^2 + a^2*(-1 + e)^2*(-1 + x^2))*(-p^2 + a^2*(1 + e)^2*(-1 + x^2))*
-          (-p^2 + a^2*(-1 + e^2)*(-1 + x^2))))])))/((-4 + p)^2*p^6 + a^8*(-1 + e^2)^4*(-1 + x^2)^2 + 2*a^2*p^5*((-1 + e^2)*(4 + p) + (-4 + e^2*(-12 + p) + 3*p)*(1 - x^2)) + 
-  2*a^6*(-1 + e^2)^2*p^2*(-1 + x^2)*(-2 + 3*x^2 + e^2*(-2 + x^2)) + a^4*p^3*(-8*(-1 + e^2)^2*(1 - 3*x^2 + 2*x^4) + p*((-1 + e^2)^2 - 4*(-1 + e^4)*(-1 + x^2) + (3 + e^2)^2*(-1 + x^2)^2)));
-
-
-kr[a_,p_,e_,x_]:=(p-p (1-e)/(1+e))/(p-r3[a,p,e,x](1-e))(r3[a,p,e,x]-r4[a,p,e,x])/(p/(1+e)-r4[a,p,e,x])
-k\[Theta][a_,p_,e_,x_]:=(1-x^2)(1-e^2)a^4/(p^2 \[Pi]xReduced[a,p,e,x]);
-rPlus[a_]:=1+Sqrt[1-a^2];
-rMinus[a_]:=1-Sqrt[1-a^2];
-hPlus[a_,p_,e_,x_]:=(p-p (1-e)/(1+e))/(p-r3[a,p,e,x](1-e))(r3[a,p,e,x]-rPlus[a])/(p/(1+e)-rPlus[a]);
-hMinus[a_,p_,e_,x_]:=(p-p (1-e)/(1+e))/(p-r3[a,p,e,x](1-e))(r3[a,p,e,x]-rMinus[a])/(p/(1+e)-rMinus[a]);
-prefactor\[Theta][a_,p_,e_,x_]:=2/Pi Sqrt[((a^2(-1+e^2)+p^2)(a^2-\[Pi]x[a,p,e,x])+2 a^2 p \[Pi]p[a,p,e,x])/(p^2 \[Pi]xReduced[a,p,e,x])];
-prefactorR[a_,p_,e_,x_]:=2a/(Pi(rPlus[a]-rMinus[a])) Sqrt[(2p+(1-e^2)\[Pi]p[a,p,e,x])/(2(p-r3[a,p,e,x](1-e))(p-r4[a,p,e,x](1+e)))];
-termRPlus[a_,p_,e_,x_]:=(2Sqrt[En2[a,p,e,x]] rPlus[a]-a Sign[x] Sqrt[L2[a,p,e,x]])/(r3[a,p,e,x]-rPlus[a])(EllipticK[kr[a,p,e,x]]-(p/(1+e)-r3[a,p,e,x])/(p/(1+e)-rPlus[a])EllipticPi[hPlus[a,p,e,x], kr[a,p,e,x]]);
-termRMinus[a_,p_,e_,x_]:=(2Sqrt[En2[a,p,e,x]] rMinus[a]-a Sign[x] Sqrt[L2[a,p,e,x]])/(r3[a,p,e,x]-rMinus[a])(EllipticK[kr[a,p,e,x]]-(p/(1+e)-r3[a,p,e,x])/(p/(1+e)-rMinus[a])EllipticPi[hMinus[a,p,e,x], kr[a,p,e,x]]);
-
-
-term\[Theta][a_,p_,e_,x_]:=prefactor\[Theta][a,p,e,x] EllipticPi[1-x^2, k\[Theta][a,p,e,x]];
-termR[a_,p_,e_,x_]:=prefactorR[a,p,e,x](termRPlus[a,p,e,x]-termRMinus[a,p,e,x]);
-
-
-r\[Phi]Ratio[a_, p_, e_, x_/;x!=0]:=Sign[x]/(Sign[x] term\[Theta][a,p,e,x]/r\[Theta]Ratio[a,p,e,x]+termR[a,p,e,x]);
-r\[Phi]Ratio[a_, p_, e_, x_/;x==0]:={1/(1/r\[Theta]Ratio[a,p,e,x]+termR[a,p,e,x]),-1/(-1/r\[Theta]Ratio[a,p,e,x]+termR[a,p,e,x])};
 
 
 (* ::Subsubsection::Closed:: *)
@@ -687,7 +763,7 @@ Options[KerrGeoOrbitRPhiResonantP]={PrecisionGoal->Automatic};
 
 
 KerrGeoOrbitRPhiResonantP[a_?NumericQ, e_?NumericQ, x_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
-Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest, pSep},
+Module[{pg,ratio,argpg,resonantEqn,pWF,pNS,pp,pgTest, pSep},
 	(*See if the user specified some precision goal *)
 	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,0,\[Beta]\[Phi]],Abort[]];
 	
@@ -695,31 +771,30 @@ Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest, pSep},
 	ratio=\[Beta]r/\[Beta]\[Phi];
 	If[x>0&&ratio<0, Message[KerrGeoFindResonance::invalidPrograde]; Abort[]];
 	If[x<0&&ratio>0, Message[KerrGeoFindResonance::invalidRetrograde]; Abort[]];
-	(* pStar provides an initial guess for p. Note that p = pStar for e = 0 and a = 0*)
-	pStar=6/(1-ratio^2);
+	pWF=6/(1-ratio^2);
 	pSep=KerrGeoSeparatrix[a,e,x];
-	
+	pNS=pNearSeparatrixr\[Phi][a,e,x,ratio,pSep];
 	(* Resonant condition defined by the equation below *)
 	If[x==0,
 		If[ratio>0,
-			resonantEqn[p_?NumericQ]:= r\[Phi]Ratio[a, p, e, x][[1]]-Abs[ratio],
-			resonantEqn[p_?NumericQ]:= r\[Phi]Ratio[a, p, e, x][[2]]-Abs[ratio]
+			resonantEqn[p_?NumericQ]:= r\[Phi]Ratio[a, p, e, x][[1]]Abs[\[Beta]\[Phi]]-\[Beta]r,
+			resonantEqn[p_?NumericQ]:= r\[Phi]Ratio[a, p, e, x][[2]]Abs[\[Beta]\[Phi]]-\[Beta]r
 		],
-		resonantEqn[p_?NumericQ]:= r\[Phi]Ratio[a, p, e, x]-Abs[ratio]
+		resonantEqn[p_?NumericQ]:= r\[Phi]Ratio[a, p, e, x]Abs[\[Beta]\[Phi]]-\[Beta]r
 	];
 	
 	(* Working precision of the root-finding method is based on the precision specified
 	 by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
 	 is the default precision if not other precision specifications are made. *)
-	argpg=Precision[{resonantEqn[pStar],a,e,x,ratio}];
+	argpg=Precision[{resonantEqn[pNS],a,e,x,ratio}];
 	If[argpg==$MachinePrecision,pg=argpg];
 	If[(Not@NumericQ[pg]||pg>argpg),pg=argpg];
 	If[pg==Infinity,pg=$MachinePrecision];
 	
 	If[pg==$MachinePrecision,
-		ResonanceSolver[resonantEqn,{pp, pStar, pSep}],
-		ResonanceSolver[resonantEqn,{pp, pStar, pSep, PrecisionGoal->pg, WorkingPrecision->pg}],
-		ResonanceSolver[resonantEqn,{pp, pStar, pSep, PrecisionGoal->pg, WorkingPrecision->pg}]
+		ResonanceSolver[resonantEqn,{pp, pSep, pWF, pNS}],
+		ResonanceSolver[resonantEqn,{pp, pSep, pWF, pNS}, PrecisionGoal->pg, WorkingPrecision->pg],
+		ResonanceSolver[resonantEqn,{pp, pSep, pWF, pNS}, PrecisionGoal->pg, WorkingPrecision->pg]
 	]
 ];
 
@@ -732,7 +807,7 @@ Options[KerrGeoOrbitRPhiResonantE]={PrecisionGoal->Automatic};
 
 
 KerrGeoOrbitRPhiResonantE[a_?NumericQ, p_?NumericQ, x_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
-Module[{pg,argpg,resonantEqn,e0Test,e1Test,eGuess,ee,ratio},
+Module[{pg,argpg,resonantEqn,p0,p1,eGuess,ee,ratio},
 	(*See if the user specified some precision goal *)
 	If[Not@ValidAQ[a]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,0,\[Beta]\[Phi]],Abort[]];
 	
@@ -743,20 +818,20 @@ Module[{pg,argpg,resonantEqn,e0Test,e1Test,eGuess,ee,ratio},
 	
 	(* Test to see if there is an eccentricity that will lead to a bound orbital resonance 
 	 based on the provided values of a, p, x *)
-	e0Test=KerrGeoOrbitRPhiResonantP[a,0,x,{\[Beta]r,\[Beta]\[Phi]},opts];
-	e1Test=KerrGeoOrbitRPhiResonantP[a,1,x,{\[Beta]r,\[Beta]\[Phi]},opts];
-	If[p<e0Test||e1Test<p, Message[KerrGeoFindResonance::noresonance, e0Test, e1Test]; Abort[];];
-	If[p==e0Test,Return[0]];
-	If[p==e1Test,Return[1]];
-	eGuess=(p-e0Test)/(e1Test-e0Test);
+	p0=KerrGeoOrbitRPhiResonantP[a,0,x,{\[Beta]r,\[Beta]\[Phi]},opts];
+	p1=KerrGeoOrbitRPhiResonantP[a,1,x,{\[Beta]r,\[Beta]\[Phi]},opts];
+	If[p<p0||p1<p, Message[KerrGeoFindResonance::noresonance, p0, p1]; Abort[];];
+	If[p==p0,Return[0]];
+	If[p==p1,Return[1]];
+	eGuess=(p-p0)/(p1-p0);
 
 	(* Resonant condition defined by the equation below *)
 	If[x==0,
 		If[ratio>0,
-			resonantEqn[e_?NumericQ]:= r\[Phi]Ratio[a, p, e, x][[1]]-Abs[ratio],
-			resonantEqn[e_?NumericQ]:= r\[Phi]Ratio[a, p, e, x][[2]]-Abs[ratio]
+			resonantEqn[e_?NumericQ]:= r\[Phi]Ratio[a, p, e, x][[1]]Abs[\[Beta]\[Phi]]-\[Beta]r,
+			resonantEqn[e_?NumericQ]:= r\[Phi]Ratio[a, p, e, x][[2]]Abs[\[Beta]\[Phi]]-\[Beta]r
 		],
-		resonantEqn[e_?NumericQ]:= r\[Phi]Ratio[a, p, e, x]-Abs[ratio]
+		resonantEqn[e_?NumericQ]:= r\[Phi]Ratio[a, p, e, x]Abs[\[Beta]\[Phi]]-\[Beta]r
 	];
 	
 	(* Working precision of the root-finding method is based on the precision specified
@@ -783,32 +858,24 @@ Options[KerrGeoOrbitRPhiResonantX]={PrecisionGoal->Automatic};
 
 
 KerrGeoOrbitRPhiResonantX[a_?NumericQ, p_?NumericQ, e_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
-Module[{pg,rtt,argpg,resonantEqn,x0Test, x1Test, x0Test1,x0Test2,x1Test1,x1Test2,xGuess,xx1,xx2,xx,ratio},
+Module[{pg,rtt,argpg,resonantEqn,p0, p1,xGuess,xx,ratio},
 	(*See if the user specified some precision goal *)
 	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidResIntQ[\[Beta]r,0,\[Beta]\[Phi]],Abort[]];
 	pg=OptionValue[PrecisionGoal];
 	ratio=\[Beta]r/\[Beta]\[Phi];
-	
-	(* Test to see if there is an eccentricity that will lead to a bound orbital resonance 
-	based on the provided values of a, p, x *)
-	(*See if the user specified some precision goal *)
-	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Theta]],Abort[]];
-
-	pg=OptionValue[PrecisionGoal];
-	ratio=\[Beta]r/\[Beta]\[Phi];
 	(* Test to see if there is an inclination angle that will lead to a bound orbital resonance 
 	 based on the provided values of a, p, e *)
-	x0Test=KerrGeoOrbitRPhiResonantP[a,e,0,{\[Beta]r,\[Beta]\[Phi]},opts];
-	x1Test=KerrGeoOrbitRPhiResonantP[a,e,Sign[ratio],{\[Beta]r,\[Beta]\[Phi]},opts];
+	p0=KerrGeoOrbitRPhiResonantP[a,e,0,{\[Beta]r,\[Beta]\[Phi]},opts];
+	p1=KerrGeoOrbitRPhiResonantP[a,e,Sign[ratio],{\[Beta]r,\[Beta]\[Phi]},opts];
 	
-	If[ratio>0 && (p<x1Test||x0Test<p), Message[KerrGeoFindResonance::noresonance, x1Test, x0Test]; Abort[];];
-	If[ratio<0 && (p<x0Test||x1Test<p), Message[KerrGeoFindResonance::noresonance, x0Test, x1Test]; Abort[];];
-	If[p==x0Test,Return[0]];
-	If[p==x1Test,Return[Sign[ratio]]];
-	xGuess=Sign[ratio](p-x0Test)/(x1Test-x0Test);
+	If[ratio>0 && (p<p1||p0<p), Message[KerrGeoFindResonance::noresonance, x1Test, x0Test]; Abort[];];
+	If[ratio<0 && (p<p0||p1<p), Message[KerrGeoFindResonance::noresonance, x0Test, x1Test]; Abort[];];
+	If[p==p0,Return[0]];
+	If[p==p1,Return[Sign[ratio]]];
+	xGuess=Sign[ratio](p-p0)/(p1-p0);
 
 	(* Resonant condition defined by the equation below *)
-	resonantEqn[x_?NumericQ]:=r\[Phi]Ratio[a, p, e, x]-Abs[ratio];
+	resonantEqn[x_?NumericQ]:=r\[Phi]Ratio[a, p, e, x]Abs[\[Beta]\[Phi]]-\[Beta]r;
 	
 	(* Working precision of the root-finding method is based on the precision specified
 	 by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
@@ -819,31 +886,41 @@ Module[{pg,rtt,argpg,resonantEqn,x0Test, x1Test, x0Test1,x0Test2,x1Test1,x1Test2
 	If[pg==Infinity,pg=$MachinePrecision];
 
 	If[pg==$MachinePrecision,
-		xxx=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess}]],
-		xxx=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess},PrecisionGoal->pg,WorkingPrecision->0.95argpg]],
-		xxx=Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess},PrecisionGoal->pg,WorkingPrecision->0.95argpg]]
+		Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess}]],
+		Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess},PrecisionGoal->pg,WorkingPrecision->0.95argpg]],
+		Re[xx/.FindRoot[resonantEqn[xx],{xx,xGuess},PrecisionGoal->pg,WorkingPrecision->0.95argpg]]
 	]
 ];
 
 
-(* ::Subsection:: *)
+(* ::Subsection::Closed:: *)
 (*\[Phi]\[Theta]-resonance*)
 
 
 (* ::Subsubsection::Closed:: *)
-(*Testing functions*)
+(*Max/Min \[Phi]\[Theta]-ratio of prograde/retrograde orbits*)
 
 
-(* ::Text:: *)
-(*Same as those of r\[Theta]-resonance*)
-
-
-(* ::Subsubsection::Closed:: *)
-(*Useful functions for root-finding*)
-
-
-\[Phi]\[Theta]Ratio[a_, p_, e_, x_/;x!=0]:=term\[Theta][a,p,e,x]+Sign[x]r\[Theta]Ratio[a,p,e,x]termR[a,p,e,x];
-\[Phi]\[Theta]Ratio[a_, p_, e_, x_/;x==0]:={1+r\[Theta]Ratio[a,p,e,x]termR[a,p,e,x],1-r\[Theta]Ratio[a,p,e,x]termR[a,p,e,x]};
+Bound\[Phi]\[Theta]Ratio[a_, e_, x_, ps1_:Automatic, xSign1_:Null]:=
+Module[{ps=ps1, xSign=xSign1, En, L, Q, r1, r2, r3, r4, zp, zm, rp, rm,term},
+	If[ps==Automatic, ps=KerrGeoSeparatrix[a,e,x]];
+	{En,L,Q} = Values[KerrGeoConstantsOfMotion[a,ps,e,x]];
+	{r1,r2,r3,r4} = KerrGeodesics`OrbitalFrequencies`Private`KerrGeoRadialRoots[a,ps,e,x,En,Q];
+	r3=r2;
+	{zp,zm}= KerrGeodesics`OrbitalFrequencies`Private`KerrGeoPolarRoots[a,ps,e,x];
+	rp = 1+Sqrt[1-a^2];
+	rm = 1-Sqrt[1-a^2];
+	term = 2a EllipticK[zm^2a^2(1-En^2)/zp^2]/(Pi Sqrt[a^2 x^2(1-En^2)+L^2+Q])(2En r3-a L)/(r3-rp)/(r3-rm);
+	If[x==0,
+		If[xSign==Null,Return[{1+term, 1-term}]];
+		If[xSign==1,Return[1+term]];
+		If[xSign==-1,Return[1-term]];,
+		If[e==1, 
+			Return[1+Sign[x]term];,
+			Return[2 Abs[L]/(Pi zp)EllipticPi[zm^2,zm^2 a^2(1-En)^2/zp^2]+Sign[x]term];
+		]
+	];
+]
 
 
 (* ::Subsubsection::Closed:: *)
@@ -854,7 +931,7 @@ Options[KerrGeoOrbitPhiThetaResonantP]={PrecisionGoal->Automatic};
 
 
 KerrGeoOrbitPhiThetaResonantP[a_?NumericQ, e_?NumericQ, x_?NumericQ, {\[Beta]\[Theta]_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
-Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest,pSep},
+Module[{pg,ratio,argpg,resonantEqn,pWF,pNS,pp,pgTest,pSep,bound},
 	(*See if the user specified some precision goal *)
 	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidXQ[x]||Not@ValidResIntQ[0,\[Beta]\[Theta],\[Beta]\[Phi]],Abort[]];
 	
@@ -862,30 +939,33 @@ Module[{pg,ratio,argpg,resonantEqn,pStar,pp,pgTest,pSep},
 	ratio=\[Beta]\[Phi]/\[Beta]\[Theta];
 	If[x>0&&ratio<1, Message[KerrGeoFindResonance::invalidPrograde]; Abort[]];
 	If[x<0&&ratio>1, Message[KerrGeoFindResonance::invalidRetrograde]; Abort[]];
-	(* pStar provides an initial guess for p. Note that p = pStar for e = 0*)
-	pStar=(2 a/Abs[ratio-1])^(2/3);
+	pWF=(2 a/Abs[ratio-1])^(2/3);
 	pSep=KerrGeoSeparatrix[a,e,x];
+	pNS=pNearSeparatrix\[Phi]\[Theta][a,e,x,ratio,pSep];
+	bound = Bound\[Phi]\[Theta]Ratio[a, e, x, pSep, Sign[ratio-1]];
 	(* Resonant condition defined by the equation below *)
+	If[\[Beta]\[Phi]==bound \[Beta]\[Theta], Return[pSep]];
+	If[\[Beta]\[Phi]>bound \[Beta]\[Theta], Message[KerrGeoFindResonance::exceedBoundRatio,bound];Abort[]];
 	If[x==0,
 		If[ratio>1,
-			resonantEqn[p_?NumericQ]:= \[Phi]\[Theta]Ratio[a, p, e, x][[1]]-Abs[ratio],
-			resonantEqn[p_?NumericQ]:= \[Phi]\[Theta]Ratio[a, p, e, x][[2]]-Abs[ratio]
+			resonantEqn[p_?NumericQ]:= \[Phi]\[Theta]Ratio[a, p, e, x][[1]]\[Beta]\[Theta]-\[Beta]\[Phi],
+			resonantEqn[p_?NumericQ]:= \[Phi]\[Theta]Ratio[a, p, e, x][[2]]\[Beta]\[Theta]-\[Beta]\[Phi]
 		],
-		resonantEqn[p_?NumericQ]:= \[Phi]\[Theta]Ratio[a, p, e, x]-Abs[ratio]
+		resonantEqn[p_?NumericQ]:= \[Phi]\[Theta]Ratio[a, p, e, x]\[Beta]\[Theta]-\[Beta]\[Phi]
 	];
 	
 	(* Working precision of the root-finding method is based on the precision specified
 	 by the PrecisionGoal option, or the precision of the arguments. MachinePrecision
 	 is the default precision if not other precision specifications are made. *)
-	argpg=Precision[{resonantEqn[pStar],a,e,x,ratio}];
+	argpg=Precision[{resonantEqn[pNS],a,e,x,ratio}];
 	If[argpg==$MachinePrecision,pg=argpg];
 	If[(Not@NumericQ[pg]||pg>argpg),pg=argpg];
 	If[pg==Infinity,pg=$MachinePrecision];
 	
 	If[pg==$MachinePrecision,
-		ResonanceSolver[resonantEqn,{pp, pStar, pSep}],
-		ResonanceSolver[resonantEqn,{pp, pStar, pSep, PrecisionGoal->pg, WorkingPrecision->pg}],
-		ResonanceSolver[resonantEqn,{pp, pStar, pSep, PrecisionGoal->pg, WorkingPrecision->pg}]
+		ResonanceSolver[resonantEqn,{pp, pSep, pWF, pNS}],
+		ResonanceSolver[resonantEqn,{pp, pSep, pWF, pNS}, PrecisionGoal->pg, WorkingPrecision->pg],
+		ResonanceSolver[resonantEqn,{pp, pSep, pWF, pNS}, PrecisionGoal->pg, WorkingPrecision->pg]
 	]
 ];
 
@@ -898,7 +978,7 @@ Options[KerrGeoOrbitPhiThetaResonantE]={PrecisionGoal->Automatic};
 
 
 KerrGeoOrbitPhiThetaResonantE[a_?NumericQ, p_?NumericQ, x_?NumericQ, {\[Beta]\[Theta]_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
-Module[{pg,argpg,resonantEqn,e0Test,e1Test,eGuess,ee,ratio},
+Module[{pg,argpg,resonantEqn,p0,p1,e0, eGuess,ee,ratio,bound0,bound1, f},
 	(*See if the user specified some precision goal *)
 	If[Not@ValidAQ[a]||Not@ValidXQ[x]||Not@ValidResIntQ[0,\[Beta]\[Theta],\[Beta]\[Phi]],Abort[]];
 	
@@ -906,15 +986,28 @@ Module[{pg,argpg,resonantEqn,e0Test,e1Test,eGuess,ee,ratio},
 	ratio=\[Beta]\[Phi]/\[Beta]\[Theta];
 	If[x>0&&ratio<1, Message[KerrGeoFindResonance::invalidPrograde]; Abort[]];
 	If[x<0&&ratio>1, Message[KerrGeoFindResonance::invalidRetrograde]; Abort[]];
-	
+	bound0 = Bound\[Phi]\[Theta]Ratio[a, 0, x, Automatic, Sign[ratio-1]];
+	bound1 = Bound\[Phi]\[Theta]Ratio[a, 1, x, Automatic, Sign[ratio-1]];
+	If[\[Beta]\[Theta]<bound1 \[Beta]\[Theta]<\[Beta]\[Phi],
+		Message[KerrGeoFindResonance::exceedBoundRatio,bound1];
+		Abort[];
+	];
+	If[\[Beta]\[Theta]<\[Beta]\[Phi]<bound0 \[Beta]\[Theta],
+		e0 = 0;
+		p0 = KerrGeoOrbitPhiThetaResonantP[a, e0, x, {\[Beta]\[Theta], \[Beta]\[Phi]},opts];	
+	];
+	If[bound0 \[Beta]\[Theta]<\[Beta]\[Phi]<bound1 \[Beta]\[Theta],
+		f[ee_]:= Bound\[Phi]\[Theta]Ratio[a,ee,x,Automatic,Sign[ratio-1]]-ratio;
+		e0 = ee/.FindRoot[f[ee],{ee,0,1}];
+		p0 = KerrGeoSeparatrix[a,e0,x];
+	];
 	(* Test to see if there is an eccentricity that will lead to a bound orbital resonance 
 	 based on the provided values of a, p, x *)
-	e0Test=KerrGeoOrbitPhiThetaResonantP[a,0,x,{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
-	e1Test=KerrGeoOrbitPhiThetaResonantP[a,1,x,{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
-	If[p<e0Test||e1Test<p, Message[KerrGeoFindResonance::noresonance, e0Test, e1Test]; Abort[];];
-	If[p==e0Test,Return[0]];
-	If[p==e1Test,Return[1]];
-	eGuess=(p-e0Test)/(e1Test-e0Test);
+	p1 = KerrGeoOrbitPhiThetaResonantP[a,1,x,{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
+	If[p<p0||p1<p, Message[KerrGeoFindResonance::noresonance, p0, p1]; Abort[];];
+	If[p==p0,Return[0]];
+	If[p==p1,Return[1]];
+	eGuess=(1-e0)(p-p0)/(p1-p0)+e0;
 
 	(* Resonant condition defined by the equation below *)
 	If[x==0,
@@ -949,7 +1042,7 @@ Options[KerrGeoOrbitPhiThetaResonantX]={PrecisionGoal->Automatic};
 
 
 KerrGeoOrbitPhiThetaResonantX[a_?NumericQ, p_?NumericQ, e_?NumericQ, {\[Beta]\[Theta]_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
-Module[{pg,argpg,resonantEqn,x0Test, x1Test,xGuess,xx,ratio},
+Module[{pg,argpg,resonantEqn,p0, p1,bound0, bound1,x0,x1,xGuess,xx,ratio,f},
 	(* Test to see if there is an eccentricity that will lead to a bound orbital resonance 
 	based on the provided values of a, p, x *)
 	(*See if the user specified some precision goal *)
@@ -959,14 +1052,55 @@ Module[{pg,argpg,resonantEqn,x0Test, x1Test,xGuess,xx,ratio},
 	ratio=\[Beta]\[Phi]/\[Beta]\[Theta];
 	(* Test to see if there is an inclination angle that will lead to a bound orbital resonance 
 	 based on the provided values of a, p, e *)
-	x0Test=KerrGeoOrbitPhiThetaResonantP[a,e,0,{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
-	x1Test=KerrGeoOrbitPhiThetaResonantP[a,e,Sign[ratio-1],{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
+	bound0 = Bound\[Phi]\[Theta]Ratio[a, e, 0, Automatic, Sign[ratio-1]];
+	bound1 = Bound\[Phi]\[Theta]Ratio[a, e, Sign[ratio-1], Automatic, Sign[ratio-1]];
+	If[ratio>1,
+		If[\[Beta]\[Phi] > \[Beta]\[Theta] bound1,
+			Message[KerrGeoFindResonance::exceedBoundRatio,bound1];
+			Abort[];
+		];
+		If[\[Beta]\[Theta] bound0<\[Beta]\[Phi]< \[Beta]\[Theta] bound1,
+			f[ee_]:= Bound\[Phi]\[Theta]Ratio[a,e,xx,Automatic,Sign[ratio-1]]-ratio;
+			x0 = xx/.FindRoot[f[xx],{xx,0,1}];
+			p0 = KerrGeoSeparatrix[a,e,x0];
+			x1 = 1;
+			p1 = KerrGeoOrbitPhiThetaResonantP[a,e,Sign[ratio-1],{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
+		];
+		If[\[Beta]\[Phi]<bound0 \[Beta]\[Theta],
+			x0 = 0;
+			p0 = KerrGeoOrbitPhiThetaResonantP[a,e,0,{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
+			x1 = 1;
+			p1 = KerrGeoOrbitPhiThetaResonantP[a,e,Sign[ratio-1],{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
+		];
+		If[p<p1||p0<p, Message[KerrGeoFindResonance::noresonance, p1, p0]; Abort[];];
+		If[p==p0,Return[x0]];
+		If[p==p1,Return[x1]];
+		xGuess = (1-x0)(p-p0)/(p1-p0)+x0;
+	];
+	If[ratio<1,
+		If[\[Beta]\[Phi] > \[Beta]\[Theta] bound0,
+			Message[KerrGeoFindResonance::exceedBoundRatio,bound0];
+			Abort[];
+		];
+		If[\[Beta]\[Theta] bound1<\[Beta]\[Phi]< \[Beta]\[Theta] bound0,
+			f[xx_]:= Bound\[Phi]\[Theta]Ratio[a,e,xx,Automatic,Sign[ratio-1]]-ratio;
+			x1 = xx/.FindRoot[f[xx],{xx,0,1}];
+			p1 = KerrGeoSeparatrix[a,e,x1];
+			x0 = 0;
+			p0 = KerrGeoOrbitPhiThetaResonantP[a,e,0,{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
+		];
+		If[\[Beta]\[Phi]<bound1 \[Beta]\[Theta],
+			x0 = 0;
+			p0 = KerrGeoOrbitPhiThetaResonantP[a,e,0,{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
+			x1 = -1;
+			p1 = KerrGeoOrbitPhiThetaResonantP[a,e,Sign[ratio-1],{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
+		];
+		If[p<p0||p1<p, Message[KerrGeoFindResonance::noresonance, p0, p1]; Abort[];];
+		If[p==p0,Return[x0]];
+		If[p==p1,Return[x1]];
+		xGuess = -x1(p-p1)/(p0-p1)+x1;
+	];
 	
-	If[ratio>1 && (p<x1Test||x0Test<p), Message[KerrGeoFindResonance::noresonance, x1Test, x0Test]; Abort[];];
-	If[ratio<1 && (p<x0Test||x1Test<p), Message[KerrGeoFindResonance::noresonance, x0Test, x1Test]; Abort[];];
-	If[p==x0Test,Return[0]];
-	If[p==x1Test,Return[Sign[ratio-1]]];
-	xGuess=Sign[ratio-1](p-x0Test)/(x1Test-x0Test);
 
 	(* Resonant condition defined by the equation below *)
 	resonantEqn[x_?NumericQ]:=\[Phi]\[Theta]Ratio[a, p, e, x]-Abs[ratio];
@@ -987,42 +1121,59 @@ Module[{pg,argpg,resonantEqn,x0Test, x1Test,xGuess,xx,ratio},
 ];
 
 
-(* ::Subsection:: *)
+(* ::Subsection::Closed:: *)
 (*r\[Theta]\[Phi]-resonance*)
 
 
 (* ::Subsubsection::Closed:: *)
-(*Testing functions*)
-
-
-(* ::Text:: *)
-(*Same as those of r\[Theta]-resonance*)
-
-
-(* ::Subsubsection::Closed:: *)
-(*Useful functions for root-finding*)
-
-
-(* ::Text:: *)
-(*Use those of double resonances*)
-
-
-(* ::Subsubsection:: *)
-(*Given (a,e,\[Beta]r,\[Beta]\[Theta]) find (\[Beta]rmin, \[Beta]rmax)*)
+(*Given (a,e,\[Beta]\[Theta],\[Beta]\[Phi]) find (\[Beta]rmin, \[Beta]rmax)*)
 
 
 Options[KerrGeoOrbitTripleResonantPX\[Beta]r]={PrecisionGoal->Automatic};
 
 
 KerrGeoOrbitTripleResonantPX\[Beta]r[a_?NumericQ, e_?NumericQ, {\[Beta]\[Theta]_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
-Module[{pg,argpg,resonantEqnr\[Theta],resonantEqnr\[Phi],p0Test,p1Test,r\[Theta]ratio0,r\[Theta]ratio1,\[Phi]\[Theta]ratio},
-	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidXQ[x]||Not@ValidResIntQ[0,\[Beta]\[Theta],\[Beta]\[Phi]],Abort[]];
+Module[{pg,argpg,resonantEqnr\[Theta],resonantEqnr\[Phi],p0,p1,r\[Theta]ratio0,r\[Theta]ratio1,\[Phi]\[Theta]ratio, bound1, bound0},
+	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidResIntQ[0,\[Beta]\[Theta],\[Beta]\[Phi]],Abort[]];
 	\[Phi]\[Theta]ratio=\[Beta]\[Phi]/\[Beta]\[Theta];
-	p0Test=KerrGeoOrbitPhiThetaResonantP[a, e, 0, {\[Beta]\[Theta], \[Beta]\[Phi]}, opts];
-	p1Test=KerrGeoOrbitPhiThetaResonantP[a, e, Sign[\[Phi]\[Theta]ratio-1], {\[Beta]\[Theta], \[Beta]\[Phi]}, opts];
-	r\[Theta]ratio0=Sign[\[Phi]\[Theta]ratio-1]r\[Theta]Ratio[a, p0Test, e, 0];
-	r\[Theta]ratio1=Sign[\[Phi]\[Theta]ratio-1]r\[Theta]Ratio[a, p1Test, e, Sign[\[Phi]\[Theta]ratio-1]];
-	Sort[{\[Beta]\[Theta] r\[Theta]ratio0, \[Beta]\[Theta] r\[Theta]ratio1}, Less]
+	bound0 = Bound\[Phi]\[Theta]Ratio[a, e, 0, Automatic, Sign[\[Phi]\[Theta]ratio-1]];
+	bound1 = Bound\[Phi]\[Theta]Ratio[a, e, Sign[\[Phi]\[Theta]ratio-1],Automatic, Sign[\[Phi]\[Theta]ratio-1]];
+	If[\[Phi]\[Theta]ratio >1,
+		If[\[Beta]\[Phi] > \[Beta]\[Theta] bound1,
+			Message[KerrGeoFindResonance::exceedBoundRatio,bound1];
+			Abort[];
+		];
+		If[\[Beta]\[Theta] bound0<\[Beta]\[Phi]< \[Beta]\[Theta] bound1,
+			p1 = KerrGeoOrbitPhiThetaResonantP[a,e,Sign[\[Phi]\[Theta]ratio-1],{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
+			r\[Theta]ratio1=r\[Theta]Ratio[a, p1, e, Sign[\[Phi]\[Theta]ratio-1]];
+			Return[{0, r\[Theta]ratio1 Abs[\[Beta]\[Theta]]}];
+		];
+		If[\[Beta]\[Phi]<bound0 \[Beta]\[Theta],
+			p0 = KerrGeoOrbitPhiThetaResonantP[a,e,0,{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
+			p1 = KerrGeoOrbitPhiThetaResonantP[a,e,Sign[\[Phi]\[Theta]ratio-1],{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
+			r\[Theta]ratio0=r\[Theta]Ratio[a, p0, e, 0];
+			r\[Theta]ratio1=r\[Theta]Ratio[a, p1, e, Sign[\[Phi]\[Theta]ratio-1]];
+			Return[Sort[{Abs[\[Beta]\[Theta]]r\[Theta]ratio0, Abs[\[Beta]\[Theta]]r\[Theta]ratio1}, Less]];
+		];
+	];
+	If[\[Phi]\[Theta]ratio<1,
+		If[\[Beta]\[Phi] > \[Beta]\[Theta] bound0,
+			Message[KerrGeoFindResonance::exceedBoundRatio,bound0];
+			Abort[];
+		];
+		If[\[Beta]\[Theta] bound1<\[Beta]\[Phi]< \[Beta]\[Theta] bound0,
+			p0 = KerrGeoOrbitPhiThetaResonantP[a,e,0,{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
+			r\[Theta]ratio0=r\[Theta]Ratio[a, p0, e, 0];
+			Return[{0, r\[Theta]ratio0 Abs[\[Beta]\[Theta]]}];
+		];
+		If[\[Beta]\[Phi]<bound1 \[Beta]\[Theta],
+			p0 = KerrGeoOrbitPhiThetaResonantP[a,e,0,{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
+			p1 = KerrGeoOrbitPhiThetaResonantP[a,e,Sign[\[Phi]\[Theta]ratio-1],{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
+			r\[Theta]ratio0=r\[Theta]Ratio[a, p0, e, 0];
+			r\[Theta]ratio1=r\[Theta]Ratio[a, p1, e, Sign[\[Phi]\[Theta]ratio-1]];
+			Return[Sort[{Abs[\[Beta]\[Theta]]r\[Theta]ratio0, Abs[\[Beta]\[Theta]]r\[Theta]ratio1}, Less]];
+		];
+	];
 ];
 
 
@@ -1034,13 +1185,13 @@ Options[KerrGeoOrbitTripleResonantPX\[Beta]\[Theta]]={PrecisionGoal->Automatic};
 
 
 KerrGeoOrbitTripleResonantPX\[Beta]\[Theta][a_?NumericQ, e_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
-Module[{pg,argpg,resonantEqnr\[Theta],resonantEqnr\[Phi],p0Test,p1Test,r\[Theta]ratio0,r\[Theta]ratio1,r\[Phi]ratio},
-	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,0,\[Beta]\[Phi]],Abort[]];
+Module[{pg,argpg,resonantEqnr\[Theta],resonantEqnr\[Phi],p0,p1,r\[Theta]ratio0,r\[Theta]ratio1,r\[Phi]ratio},
+	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidResIntQ[\[Beta]r,0,\[Beta]\[Phi]],Abort[]];
 	r\[Phi]ratio=\[Beta]r/\[Beta]\[Phi];
-	p0Test=KerrGeoOrbitRPhiResonantP[a, e, 0, {\[Beta]r, \[Beta]\[Phi]}, opts];
-	p1Test=KerrGeoOrbitRPhiResonantP[a, e, Sign[r\[Phi]ratio], {\[Beta]r, \[Beta]\[Phi]}, opts];
-	r\[Theta]ratio0=Sign[r\[Phi]ratio]r\[Theta]Ratio[a, p0Test, e, 0];
-	r\[Theta]ratio1=Sign[r\[Phi]ratio]r\[Theta]Ratio[a, p1Test, e, Sign[r\[Phi]ratio]];
+	p0=KerrGeoOrbitRPhiResonantP[a, e, 0, {\[Beta]r, \[Beta]\[Phi]}, opts];
+	p1=KerrGeoOrbitRPhiResonantP[a, e, Sign[r\[Phi]ratio], {\[Beta]r, \[Beta]\[Phi]}, opts];
+	r\[Theta]ratio0=Sign[r\[Phi]ratio]r\[Theta]Ratio[a, p0, e, 0];
+	r\[Theta]ratio1=Sign[r\[Phi]ratio]r\[Theta]Ratio[a, p1, e, Sign[r\[Phi]ratio]];
 	Sort[{\[Beta]r/r\[Theta]ratio0, \[Beta]r/r\[Theta]ratio1}, Less]
 ];
 
@@ -1053,13 +1204,13 @@ Options[KerrGeoOrbitTripleResonantPX\[Beta]\[Phi]]={PrecisionGoal->Automatic};
 
 
 KerrGeoOrbitTripleResonantPX\[Beta]\[Phi][a_?NumericQ, e_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Theta]_Integer}, opts:OptionsPattern[]]:=
-Module[{pg,argpg,resonantEqnr\[Theta],resonantEqnr\[Phi],p0Test,p1Test,r\[Phi]ratio0,r\[Phi]ratio1,r\[Theta]ratio},
-	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Theta],0],Abort[]];
+Module[{pg,argpg,resonantEqnr\[Theta],resonantEqnr\[Phi],p0,p1,r\[Phi]ratio0,r\[Phi]ratio1,r\[Theta]ratio},
+	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Theta],0],Abort[]];
 	r\[Theta]ratio=\[Beta]r/\[Beta]\[Theta];
-	p0Test=KerrGeoOrbitRThetaResonantP[a, e, 0, {\[Beta]r, \[Beta]\[Theta]}, opts];
-	p1Test=KerrGeoOrbitRThetaResonantP[a, e, Sign[r\[Theta]ratio], {\[Beta]r, \[Beta]\[Theta]}, opts];
-	r\[Phi]ratio0=Sign[r\[Theta]ratio]If[r\[Theta]ratio>0, r\[Phi]Ratio[a, p0Test, e, 0][[1]], r\[Phi]Ratio[a, p0Test, e, 0][[2]]];
-	r\[Phi]ratio1=Sign[r\[Theta]ratio]r\[Phi]Ratio[a, p1Test, e, Sign[r\[Theta]ratio]];
+	p0=KerrGeoOrbitRThetaResonantP[a, e, 0, {\[Beta]r, \[Beta]\[Theta]}, opts];
+	p1=KerrGeoOrbitRThetaResonantP[a, e, Sign[r\[Theta]ratio], {\[Beta]r, \[Beta]\[Theta]}, opts];
+	r\[Phi]ratio0=Sign[r\[Theta]ratio]If[r\[Theta]ratio>0, r\[Phi]Ratio[a, p0, e, 0][[1]], r\[Phi]Ratio[a, p0, e, 0][[2]]];
+	r\[Phi]ratio1=Sign[r\[Theta]ratio]r\[Phi]Ratio[a, p1, e, Sign[r\[Theta]ratio]];
 	Sort[{\[Beta]r/r\[Phi]ratio0, \[Beta]r/r\[Phi]ratio1}, Less]
 ];
 
@@ -1072,18 +1223,18 @@ Options[KerrGeoOrbitTripleResonantPX]={PrecisionGoal->Automatic};
 
 
 KerrGeoOrbitTripleResonantPX[a_?NumericQ, e_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Theta]_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
-Module[{pg,argpg,resonantEqnr\[Theta],resonantEqnr\[Phi],pGuess,xGuess,pp,xx,r\[Theta]ratio,r\[Phi]ratio,p0r\[Theta]Test,p1r\[Theta]Test,p0r\[Phi]Test,p1r\[Phi]Test,p0\[Phi]\[Theta]Test,p1\[Phi]\[Theta]Test,checkSolution, rInts, \[Theta]Ints, \[Phi]Ints},
+Module[{pg,argpg,resonantEqnr\[Theta],resonantEqnr\[Phi],pGuess,xGuess,pp,xx,r\[Theta]ratio,r\[Phi]ratio,p0r\[Theta],p1r\[Theta],p0r\[Phi],p1r\[Phi],p0\[Phi]\[Theta],p1\[Phi]\[Theta],checkSolution, rInts, \[Theta]Ints, \[Phi]Ints},
 	(*See if the user specified some precision goal *)
-	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidXQ[x]||Not@ValidResIntQ[0,\[Beta]\[Theta],\[Beta]\[Phi]],Abort[]];
+	If[Not@ValidAQ[a]||Not@ValidEQ[e]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Theta],\[Beta]\[Phi]],Abort[]];
 	
 	pg=OptionValue[PrecisionGoal];
 	r\[Theta]ratio=\[Beta]r/\[Beta]\[Theta];
 	r\[Phi]ratio=\[Beta]r/\[Beta]\[Phi];
-	p0r\[Theta]Test=KerrGeoOrbitRThetaResonantP[a, e, 0, {\[Beta]r, \[Beta]\[Theta]},opts];
-	p1r\[Theta]Test=KerrGeoOrbitRThetaResonantP[a, e, Sign[r\[Theta]ratio], {\[Beta]r, \[Beta]\[Theta]},opts];
-	p0r\[Phi]Test=KerrGeoOrbitRPhiResonantP[a, e, 0, {\[Beta]r, \[Beta]\[Phi]},opts];
-	p1r\[Phi]Test=KerrGeoOrbitRPhiResonantP[a, e, Sign[r\[Phi]ratio], {\[Beta]r, \[Beta]\[Phi]},opts];
-	checkSolution=(p0r\[Theta]Test-p0r\[Phi]Test)(p1r\[Theta]Test-p1r\[Phi]Test);
+	p0r\[Theta]=KerrGeoOrbitRThetaResonantP[a, e, 0, {\[Beta]r, \[Beta]\[Theta]},opts];
+	p1r\[Theta]=KerrGeoOrbitRThetaResonantP[a, e, Sign[r\[Theta]ratio], {\[Beta]r, \[Beta]\[Theta]},opts];
+	p0r\[Phi]=KerrGeoOrbitRPhiResonantP[a, e, 0, {\[Beta]r, \[Beta]\[Phi]},opts];
+	p1r\[Phi]=KerrGeoOrbitRPhiResonantP[a, e, Sign[r\[Phi]ratio], {\[Beta]r, \[Beta]\[Phi]},opts];
+	checkSolution=(p0r\[Theta]-p0r\[Phi])(p1r\[Theta]-p1r\[Phi]);
 	If[checkSolution>0,
 		rInts=KerrGeoOrbitTripleResonantPX\[Beta]r[a, e, {\[Beta]\[Theta], \[Beta]\[Phi]}, opts];
 		\[Theta]Ints=KerrGeoOrbitTripleResonantPX\[Beta]\[Theta][a, e, {\[Beta]r, \[Beta]\[Phi]}, opts];
@@ -1091,8 +1242,8 @@ Module[{pg,argpg,resonantEqnr\[Theta],resonantEqnr\[Phi],pGuess,xGuess,pp,xx,r\[
 		Message[KerrGeoFindResonance::noTripleResonance,rInts[[1]],rInts[[2]],\[Theta]Ints[[1]],\[Theta]Ints[[2]],\[Phi]Ints[[1]],\[Phi]Ints[[2]]];
 		Abort[]];
 	
-	xGuess=Sign[r\[Theta]ratio]/((p1r\[Phi]Test-p1r\[Theta]Test)/(p0r\[Theta]Test-p0r\[Phi]Test)+1);
-	pGuess=p0r\[Theta]Test-Sign[r\[Theta]ratio]xGuess(p0r\[Theta]Test-p1r\[Theta]Test);
+	xGuess=Sign[r\[Theta]ratio]/((p1r\[Phi]-p1r\[Theta])/(p0r\[Theta]-p0r\[Phi])+1);
+	pGuess=p0r\[Theta]-Sign[r\[Theta]ratio]xGuess(p0r\[Theta]-p1r\[Theta]);
 	resonantEqnr\[Theta][p_?NumericQ, x_?NumericQ]:=r\[Theta]Ratio[a, p, e, x]-Abs[r\[Theta]ratio];
 	resonantEqnr\[Phi][p_?NumericQ, x_?NumericQ]:=r\[Phi]Ratio[a, p, e, x]-Abs[r\[Phi]ratio];
 	argpg=Precision[{a,e,r\[Theta]ratio,r\[Phi]ratio,resonantEqnr\[Theta][pGuess, xGuess],resonantEqnr\[Phi][pGuess, xGuess]}];
@@ -1107,6 +1258,119 @@ Module[{pg,argpg,resonantEqnr\[Theta],resonantEqnr\[Phi],pGuess,xGuess,pp,xx,r\[
 ];
 
 
+(* ::Subsubsection:: *)
+(*Given (a,x,\[Beta]\[Theta],\[Beta]\[Phi]) find (\[Beta]rmin, \[Beta]rmax)*)
+
+
+Options[KerrGeoOrbitTripleResonantPE\[Beta]r]={PrecisionGoal->Automatic};
+
+
+KerrGeoOrbitTripleResonantPE\[Beta]r[a_?NumericQ, x_?NumericQ, {\[Beta]\[Theta]_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
+Module[{pg,argpg,resonantEqnr\[Theta],resonantEqnr\[Phi],p0,p1,r\[Theta]ratio0,r\[Theta]ratio1,\[Phi]\[Theta]ratio, bound1, bound0},
+	If[Not@ValidAQ[a]||Not@ValidXQ[x]||Not@ValidResIntQ[0,\[Beta]\[Theta],\[Beta]\[Phi]],Abort[]];
+	\[Phi]\[Theta]ratio=\[Beta]\[Phi]/\[Beta]\[Theta];
+	bound0 = Bound\[Phi]\[Theta]Ratio[a, 0, x, Automatic, Sign[\[Phi]\[Theta]ratio-1]];
+	bound1 = Bound\[Phi]\[Theta]Ratio[a, 1, x, Automatic, Sign[\[Phi]\[Theta]ratio-1]];
+	If[\[Beta]\[Theta]<bound1 \[Beta]\[Theta]<\[Beta]\[Phi],
+		Message[KerrGeoFindResonance::exceedBoundRatio,bound1];
+		Abort[];
+	];
+	If[\[Beta]\[Theta]<\[Beta]\[Phi]<bound0 \[Beta]\[Theta],
+		p0 = KerrGeoOrbitPhiThetaResonantP[a,0,x,{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
+		p1 = KerrGeoOrbitPhiThetaResonantP[a,1,x,{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
+		r\[Theta]ratio0=r\[Theta]Ratio[a, p0, 0, x];
+		r\[Theta]ratio1=r\[Theta]Ratio[a, p1, 1, x];
+		Return[Sort[{Abs[\[Beta]\[Theta]]r\[Theta]ratio0, Abs[\[Beta]\[Theta]]r\[Theta]ratio1}, Less]];
+	];
+	If[bound0 \[Beta]\[Theta]<\[Beta]\[Phi]<bound1 \[Beta]\[Theta],
+		p1 = KerrGeoOrbitPhiThetaResonantP[a,1,x,{\[Beta]\[Theta],\[Beta]\[Phi]},opts];
+		r\[Theta]ratio1=r\[Theta]Ratio[a, p1, 1, x];
+		Return[{0, Abs[\[Beta]\[Theta]]r\[Theta]ratio1}]
+	];
+];
+
+
+(* ::Subsubsection:: *)
+(*Given (a,x,\[Beta]r,\[Beta]\[Phi]) find (\[Beta]\[Theta]min, \[Beta]\[Theta]max)*)
+
+
+Options[KerrGeoOrbitTripleResonantPE\[Beta]\[Theta]]={PrecisionGoal->Automatic};
+
+
+KerrGeoOrbitTripleResonantPE\[Beta]\[Theta][a_?NumericQ, x_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
+Module[{pg,argpg,resonantEqnr\[Theta],resonantEqnr\[Phi],p0,p1,r\[Theta]ratio0,r\[Theta]ratio1,r\[Phi]ratio},
+	If[Not@ValidAQ[a]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,0,\[Beta]\[Phi]],Abort[]];
+	r\[Phi]ratio=\[Beta]r/\[Beta]\[Phi];
+	p0=KerrGeoOrbitRPhiResonantP[a, 0, x, {\[Beta]r, \[Beta]\[Phi]}, opts];
+	p1=KerrGeoOrbitRPhiResonantP[a, 1, x, {\[Beta]r, \[Beta]\[Phi]}, opts];
+	r\[Theta]ratio0=Sign[r\[Phi]ratio]r\[Theta]Ratio[a, p0, 0, x];
+	r\[Theta]ratio1=Sign[r\[Phi]ratio]r\[Theta]Ratio[a, p1, 1, x];
+	Sort[{\[Beta]r/r\[Theta]ratio0, \[Beta]r/r\[Theta]ratio1}, Less]
+];
+
+
+(* ::Subsubsection:: *)
+(*Given (a,x,\[Beta]r,\[Beta]\[Theta]) find (\[Beta]\[Phi]min, \[Beta]\[Phi]max)*)
+
+
+Options[KerrGeoOrbitTripleResonantPE\[Beta]\[Phi]]={PrecisionGoal->Automatic};
+
+
+KerrGeoOrbitTripleResonantPE\[Beta]\[Phi][a_?NumericQ, x_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Theta]_Integer}, opts:OptionsPattern[]]:=
+Module[{pg,argpg,resonantEqnr\[Theta],resonantEqnr\[Phi],p0,p1,r\[Phi]ratio0,r\[Phi]ratio1,r\[Theta]ratio},
+	If[Not@ValidAQ[a]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Theta],0],Abort[]];
+	r\[Theta]ratio=\[Beta]r/\[Beta]\[Theta];
+	p0=KerrGeoOrbitRThetaResonantP[a, 0, x,{\[Beta]r, \[Beta]\[Theta]}, opts];
+	p1=KerrGeoOrbitRThetaResonantP[a, 1, x, {\[Beta]r, \[Beta]\[Theta]}, opts];
+	r\[Phi]ratio0=Sign[r\[Theta]ratio]r\[Phi]Ratio[a, p0, 0, x];
+	r\[Phi]ratio1=Sign[r\[Theta]ratio]r\[Phi]Ratio[a, p1, 1, x];
+	Sort[{\[Beta]r/r\[Phi]ratio0, \[Beta]r/r\[Phi]ratio1}, Less]
+];
+
+
+(* ::Subsubsection:: *)
+(*Given (a,x,\[Beta]r,\[Beta]\[Theta],\[Beta]\[Phi]) find (p, e)*)
+
+
+Options[KerrGeoOrbitTripleResonantPE]={PrecisionGoal->Automatic};
+
+
+KerrGeoOrbitTripleResonantPE[a_?NumericQ, x_?NumericQ, {\[Beta]r_Integer, \[Beta]\[Theta]_Integer, \[Beta]\[Phi]_Integer}, opts:OptionsPattern[]]:=
+Module[{pg,argpg,resonantEqnr\[Theta],resonantEqnr\[Phi],pGuess,eGuess,pp,ee,r\[Theta]ratio,r\[Phi]ratio,p0r\[Theta],p1r\[Theta],p0r\[Phi],p1r\[Phi],p0\[Phi]\[Theta],p1\[Phi]\[Theta],checkSolution, rInts, \[Theta]Ints, \[Phi]Ints},
+	(*See if the user specified some precision goal *)
+	If[Not@ValidAQ[a]||Not@ValidXQ[x]||Not@ValidResIntQ[\[Beta]r,\[Beta]\[Theta],\[Beta]\[Phi]],Abort[]];
+	
+	pg=OptionValue[PrecisionGoal];
+	r\[Theta]ratio=\[Beta]r/\[Beta]\[Theta];
+	r\[Phi]ratio=\[Beta]r/\[Beta]\[Phi];
+	p0r\[Theta]=KerrGeoOrbitRThetaResonantP[a, 0, x, {\[Beta]r, \[Beta]\[Theta]},opts];
+	p1r\[Theta]=KerrGeoOrbitRThetaResonantP[a, 1, x, {\[Beta]r, \[Beta]\[Theta]},opts];
+	p0r\[Phi]=KerrGeoOrbitRPhiResonantP[a, 0, x, {\[Beta]r, \[Beta]\[Phi]},opts];
+	p1r\[Phi]=KerrGeoOrbitRPhiResonantP[a, 1, x, {\[Beta]r, \[Beta]\[Phi]},opts];
+	checkSolution=(p0r\[Theta]-p0r\[Phi])(p1r\[Theta]-p1r\[Phi]);
+	If[checkSolution>0,
+		rInts=KerrGeoOrbitTripleResonantPE\[Beta]r[a, x, {\[Beta]\[Theta], \[Beta]\[Phi]}, opts];
+		\[Theta]Ints=KerrGeoOrbitTripleResonantPE\[Beta]\[Theta][a, x, {\[Beta]r, \[Beta]\[Phi]}, opts];
+		\[Phi]Ints=KerrGeoOrbitTripleResonantPE\[Beta]\[Phi][a, x, {\[Beta]r, \[Beta]\[Theta]}, opts];
+		Message[KerrGeoFindResonance::noTripleResonance,rInts[[1]],rInts[[2]],\[Theta]Ints[[1]],\[Theta]Ints[[2]],\[Phi]Ints[[1]],\[Phi]Ints[[2]]];
+		Abort[]];
+	
+	eGuess=1/((p1r\[Phi]-p1r\[Theta])/(p0r\[Theta]-p0r\[Phi])+1);
+	pGuess=p0r\[Theta]-eGuess(p0r\[Theta]-p1r\[Theta]);
+	resonantEqnr\[Theta][p_?NumericQ, e_?NumericQ]:=r\[Theta]Ratio[a, p, e, x]-Abs[r\[Theta]ratio];
+	resonantEqnr\[Phi][p_?NumericQ, e_?NumericQ]:=r\[Phi]Ratio[a, p, e, x]-Abs[r\[Phi]ratio];
+	argpg=Precision[{a,x,r\[Theta]ratio,r\[Phi]ratio,resonantEqnr\[Theta][pGuess, eGuess],resonantEqnr\[Phi][pGuess, xGuess]}];
+	If[argpg==$MachinePrecision,pg=0.9argpg];
+	If[(Not@NumericQ[pg]||pg>argpg),pg=0.9argpg];
+	If[pg==Infinity,pg=$MachinePrecision];
+	If[pg==$MachinePrecision,
+		Re[{pp,ee}/.FindRoot[{resonantEqnr\[Theta][pp,ee],resonantEqnr\[Phi][pp,ee]},{{pp,pGuess},{ee,eGuess}}]],
+		Re[{pp,ee}/.FindRoot[{resonantEqnr\[Theta][pp,ee],resonantEqnr\[Phi][pp,ee]},{{pp,pGuess},{ee,eGuess}},PrecisionGoal->pg,WorkingPrecision->0.95argpg]],
+		Re[{pp,ee}/.FindRoot[{resonantEqnr\[Theta][pp,ee],resonantEqnr\[Phi][pp,ee]},{{pp,pGuess},{ee,eGuess}},PrecisionGoal->pg,WorkingPrecision->0.95argpg]]
+	]
+];
+
+
 (* ::Subsection::Closed:: *)
 (*Generic resonance interface*)
 
@@ -1114,11 +1378,15 @@ Module[{pg,argpg,resonantEqnr\[Theta],resonantEqnr\[Phi],pGuess,xGuess,pp,xx,r\[
 Options[KerrGeoFindResonance]={PrecisionGoal->Automatic};
 
 
-KerrGeoFindResonance[assoc_Association,{\[Beta]r_Integer, \[Beta]\[Theta]_Integer, \[Beta]\[Phi]_Integer},opts:OptionsPattern[]]:=Module[{pp, xx},
+KerrGeoFindResonance[assoc_Association,{\[Beta]r_Integer, \[Beta]\[Theta]_Integer, \[Beta]\[Phi]_Integer},opts:OptionsPattern[]]:=Module[{pp, xx, ee},
 	If[ContainsExactly[Keys[assoc],{"a","e"}],
 		{pp, xx}=KerrGeoOrbitTripleResonantPX["a"/.assoc, "e"/.assoc, {\[Beta]r, \[Beta]\[Theta], \[Beta]\[Phi]}, opts];
 		{"p"->pp,"x"->xx},
-		Message[KerrGeoFindResonance::assocErrTriple]
+		If[ContainsExactly[Keys[assoc],{"a","x"}],
+			{pp, ee}=KerrGeoOrbitTripleResonantPE["a"/.assoc, "e"/.assoc, {\[Beta]r, \[Beta]\[Theta], \[Beta]\[Phi]}, opts];
+			{"p"->pp,"x"->ee},
+			Message[KerrGeoFindResonance::assocErrTriple]
+		]
 	]
 ]
 


### PR DESCRIPTION
I added more options for finding resonance orbit to the existing KerrGeoFindResonance:
- Find r- $\phi$ resonance and $\phi$ - $\theta$ resonance; with given ratio, a and two of (p, e, x).
- Find triple resonance with given ratio and (a, e).
- If there is no triple resonance, there will be a message for range of possible r-integer, $\phi$ -interger and $\theta$ -integer. To get a triple resonance from the wrong one, you can change one of 3 integers by picking one value in the corresponding interval from the message and keep the other 2.

Quick guide: The syntax is similar to the existing KerrGeoFindResonance, I just modify and add things to this:
- Same as in r- $\theta$, for r - $\phi$ and $\phi$ - $\theta$, set the $\theta$ - integer and r-interger to zero, respectively
- For triple-resonance, only give (a, e) and set of non-zero integer.
- For retrograde orbits, remember to use negative integers for $\theta$ and $\phi$ input; for example:
KerrGeoFindResonance[<|"a"->0.9,  "e"->0.5,  "x"->-0.6|>, {1, 0, -2}].
This helps keeping the solution unique in some KerrGeoFindResonance options.

Caution:
- The correction result might be too close the separatrix, which makes the frequency ratio diverges; the resonant equation is unsolvable. When it happens, I set the result to KerrGeoSeparatrix[a,e,x]+10^(-5). Try to choose set of integers not far from each other, since they tend to coincide as $p$ goes to infinity.
